### PR TITLE
Use new object mapper module

### DIFF
--- a/endpoints/bahmni/input-mapping.json
+++ b/endpoints/bahmni/input-mapping.json
@@ -10,5 +10,11 @@
   "person.addresses[0].country": "address[0].country",
   "person.addresses[0].stateProvince": "address[0].state",
   "person.addresses[0].cityVillage": "address[0].city",
-  "person.uuid": "id"
+  "person.uuid": "id",
+  "person.birthdate": {
+    "key": "birthDate",
+    "transform": {
+      "function": "dateTimeToDate"
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1135,7 +1135,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1153,11 +1154,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1170,15 +1173,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1281,7 +1287,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1291,6 +1298,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1303,17 +1311,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1330,6 +1341,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1402,7 +1414,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1412,6 +1425,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1487,7 +1501,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1517,6 +1532,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1534,6 +1550,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1572,11 +1589,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -2851,9 +2870,8 @@
       "dev": true
     },
     "object-mapper": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/object-mapper/-/object-mapper-5.0.0.tgz",
-      "integrity": "sha1-ADX9Lsu/r2F7QaK/jA+lEiEDWls=",
+      "version": "github:jembi/node-object-mapper#1e25a715ad1e2e0da734f24514f668b21e9bd267",
+      "from": "github:jembi/node-object-mapper#master",
       "requires": {
         "minimatch": "^3.0.4"
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "koa-body": "^4.1.1",
     "koa-router": "^7.4.0",
     "nodemon": "^1.19.3",
-    "object-mapper": "^5.0.0",
+    "object-mapper": "jembi/node-object-mapper#master",
     "openhim-mediator-utils": "^0.2.3",
     "pino": "^5.13.4",
     "pino-pretty": "^3.2.1"


### PR DESCRIPTION
Forked original object mapper module to cater for our case.

We can't let users add their own transformation functions with risking
app security. Therefore to still allow transformations we have forker
the object mapper module and implemented a set of pre-existing functions
which can be called by providing a key which will fetch that function at
run time and use it to transform the users data.

This prevents malicious users executing code directly in the app

OHM-870# If applied, this commit will: