### PR TITLE
OHM-875: Remove the methods from meta.json config

### DIFF
--- a/endpoints/bahmni/meta.json
+++ b/endpoints/bahmni/meta.json
@@ -1,8 +1,7 @@
 {
   "name": "Bahmni Patient Mapper",
   "endpoint": {
-    "pattern": "/bahmniPatient",
-    "methods": ["POST"]
+    "pattern": "/bahmniPatient"
   },
   "transformation": {
     "input": "JSON",

--- a/endpoints/openIMIS/meta.json
+++ b/endpoints/openIMIS/meta.json
@@ -1,8 +1,7 @@
 {
   "name": "OpenIMIS Patient Mapper",
   "endpoint": {
-    "pattern": "/openIMISPatient",
-    "methods": ["POST"]
+    "pattern": "/openIMISPatient"
   },
   "transformation": {
     "input": "JSON",


### PR DESCRIPTION
As this will not currently be used. We will only be accepting POST requests which contain the body payload to map data from.
In future additions we might be adding support for more methods and to forward the request onto a destination which would require additional methods.

OHM-875