### PR TITLE
OHM-885 Fix to return response body when exception is thrown

### DIFF
--- a/src/middleware/mapper.js
+++ b/src/middleware/mapper.js
@@ -26,7 +26,8 @@ exports.transformInput = (mappingSchema, inputConstants) => async (
     createMappedObject(ctx, mappingSchema, inputConstants)
   } catch (error) {
     ctx.status = 400
-    ctx.body = error
+    ctx.type = 'json'
+    ctx.body = JSON.stringify({ error: `Transformation Failed: ${error.message}` })
     return logger.error(`Transformation Failed: ${error.message}`)
   }
   await next()

--- a/src/middleware/validator.js
+++ b/src/middleware/validator.js
@@ -93,7 +93,7 @@ exports.validateInput = validationMap => async (ctx, next) => {
   try {
     const schema = createValidationSchema(validationMap)
     performValidation(ctx, schema)
-    logger.debug('Successfully validated user input')
+    logger.info('Successfully validated user input')
   } catch (error) {
     ctx.status = 400
     ctx.type = 'json'

--- a/src/middleware/validator.js
+++ b/src/middleware/validator.js
@@ -96,7 +96,8 @@ exports.validateInput = validationMap => async (ctx, next) => {
     logger.debug('Successfully validated user input')
   } catch (error) {
     ctx.status = 400
-    ctx.body = error.message
+    ctx.type = 'json'
+    ctx.body = JSON.stringify({ error: error.message })
     return logger.error(error)
   }
 
@@ -104,7 +105,8 @@ exports.validateInput = validationMap => async (ctx, next) => {
     performValidation(ctx, schema)
   } catch (error) {
     ctx.status = 400
-    ctx.body = error.message
+    ctx.type = 'json'
+    ctx.body = JSON.stringify({ error: error.message })
     return logger.error(error)
   }
 

--- a/src/middleware/validator.js
+++ b/src/middleware/validator.js
@@ -96,7 +96,7 @@ exports.validateInput = validationMap => async (ctx, next) => {
     logger.debug('Successfully validated user input')
   } catch (error) {
     ctx.status = 400
-    ctx.body = error
+    ctx.body = error.message
     return logger.error(error)
   }
 
@@ -104,7 +104,7 @@ exports.validateInput = validationMap => async (ctx, next) => {
     performValidation(ctx, schema)
   } catch (error) {
     ctx.status = 400
-    ctx.body = error
+    ctx.body = error.message
     return logger.error(error)
   }
 

--- a/src/middleware/validator.js
+++ b/src/middleware/validator.js
@@ -90,24 +90,15 @@ const performValidation = (ctx, schema) => {
 }
 
 exports.validateInput = validationMap => async (ctx, next) => {
-  let schema
   try {
-    schema = createValidationSchema(validationMap)
+    const schema = createValidationSchema(validationMap)
+    performValidation(ctx, schema)
     logger.debug('Successfully validated user input')
   } catch (error) {
     ctx.status = 400
     ctx.type = 'json'
     ctx.body = JSON.stringify({ error: error.message })
-    return logger.error(error)
-  }
-
-  try {
-    performValidation(ctx, schema)
-  } catch (error) {
-    ctx.status = 400
-    ctx.type = 'json'
-    ctx.body = JSON.stringify({ error: error.message })
-    return logger.error(error)
+    return logger.error(error.message)
   }
 
   await next()


### PR DESCRIPTION
Prior to this change, validator was returning an empty body when
validation processing failed

Assigning the error object that the exception handler catches
results in an empty response body.
This change adds the error message to the response body when a
validation exception causes a 4xx response to be returned

OHM-885