### PR TITLE
OHM-877 Split out mediator registration and make it optional

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -8,7 +8,8 @@ exports.getConfig = function() {
       apiURL: process.env.OPENHIM_URL || 'https://localhost:8080',
       username: process.env.OPENHIM_USERNAME || 'root@openhim.org',
       password: process.env.OPENHIM_PASSWORD || 'openhim-password',
-      trustSelfSigned: process.env.TRUST_SELF_SIGNED === 'true'
+      trustSelfSigned: process.env.TRUST_SELF_SIGNED === 'true',
+      register: process.env.OPENHIM_REGISTER || 'true'
     })
   })
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,26 +3,14 @@
 const koa = require('koa')
 const koaBody = require('koa-body')
 const koaRouter = require('koa-router')
-const fs = require('fs')
-const path = require('path')
 
-const {registerMediator, activateHeartbeat} = require('openhim-mediator-utils')
-
+const openhim = require('./openhim')
 const logger = require('./logger')
 const config = require('./config')
 const routes = require('./routes')
 
-const mediatorConfigFile = fs.readFileSync(
-  path.resolve(__dirname, '..', 'mediatorConfig.json')
-)
-const mediatorConfigJson = JSON.parse(mediatorConfigFile)
-
 const configOptions = config.getConfig()
-
-const openhimConfig = Object.assign(
-  {urn: mediatorConfigJson.urn},
-  configOptions.openhim
-)
+const registerMediator = (configOptions.openhim.register == 'true')
 
 const app = new koa()
 const router = new koaRouter()
@@ -37,22 +25,7 @@ app
 app.listen(configOptions.port, () => {
   logger.info(`Server listening on port ${configOptions.port}...`)
 
-  mediatorSetup()
+  if (registerMediator) {
+    openhim.mediatorSetup()
+  }
 })
-
-const mediatorSetup = () => {
-  registerMediator(openhimConfig, mediatorConfigJson, err => {
-    if (err) {
-      logger.error('Failed to register mediator')
-      throw new Error(err.message)
-    }
-
-    logger.info('Successfully registered mediator!')
-
-    const emitter = activateHeartbeat(openhimConfig)
-
-    emitter.on('error', err => {
-      logger.error('Heartbeat failed: ', err)
-    })
-  })
-}

--- a/src/openhim.js
+++ b/src/openhim.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const {registerMediator, activateHeartbeat} = require('openhim-mediator-utils')
+
+const logger = require('./logger')
+const config = require('./config')
+
+const mediatorConfigFile = fs.readFileSync(
+  path.resolve(__dirname, '..', 'mediatorConfig.json')
+)
+const mediatorConfigJson = JSON.parse(mediatorConfigFile)
+
+const configOptions = config.getConfig()
+
+const openhimConfig = Object.assign(
+  {urn: mediatorConfigJson.urn},
+  configOptions.openhim
+)
+
+const mediatorSetup = () => {
+  registerMediator(openhimConfig, mediatorConfigJson, err => {
+    if (err) {
+      logger.error('Failed to register mediator')
+      throw new Error(err.message)
+    }
+
+    logger.info('Successfully registered mediator!')
+
+    const emitter = activateHeartbeat(openhimConfig)
+
+    emitter.on('error', err => {
+      logger.error('Heartbeat failed: ', err)
+    })
+  })
+}
+
+exports.mediatorSetup = mediatorSetup

--- a/src/openhim.js
+++ b/src/openhim.js
@@ -2,19 +2,15 @@
 
 const fs = require('fs')
 const path = require('path')
-
-const {registerMediator, activateHeartbeat} = require('openhim-mediator-utils')
-
 const logger = require('./logger')
 const config = require('./config')
+const {registerMediator, activateHeartbeat} = require('openhim-mediator-utils')
 
 const mediatorConfigFile = fs.readFileSync(
   path.resolve(__dirname, '..', 'mediatorConfig.json')
 )
 const mediatorConfigJson = JSON.parse(mediatorConfigFile)
-
 const configOptions = config.getConfig()
-
 const openhimConfig = Object.assign(
   {urn: mediatorConfigJson.urn},
   configOptions.openhim


### PR DESCRIPTION
Prior to this change, registration of the mediator with OpenHIM was
automatic, at mediator startup

This change introduces a configuration flag to indicate whether
to register this mediator with a running OpenHIM instance (true)
or not (false). The default value for the flag is true.

OHM-877