### PR TITLE
make the links arrays required

### DIFF
--- a/endpoints/bahmni/input-validation.json
+++ b/endpoints/bahmni/input-validation.json
@@ -37,7 +37,8 @@
                   }
                 }
               }
-            }
+            },
+            "required": ["links"]
           },
           "links": {
             "type": "array",
@@ -51,7 +52,8 @@
               }
             }
           }
-        }
+        },
+        "required": ["links"]
       }
     },
     "person": {


### PR DESCRIPTION
In the mapping rules, references to specific elements in the links arrays are made (identifiers[].links[0].uri: identifier[].system). A mapping failure occurs if the array is undefined. With other types, the mapping does not fail when a field is undefined. This is an issue with object-mapper.

OHM-842