### PR TITLE
correctly set the expected incoming body type

### DIFF
--- a/src/middleware/parser.js
+++ b/src/middleware/parser.js
@@ -55,11 +55,11 @@ const parseIncomingBody = async (ctx, inputFormat, next) => {
 }
 
 exports.parseBodyMiddleware = metaData => async (ctx, next) => {
-  const incomingContentType = metaData.transformation.input.toUpperCase()
+  const inputContentType = metaData.transformation.input.toUpperCase()
   const outputContentType = metaData.transformation.output.toUpperCase()
   try {
     // parse incoming body
-    await parseIncomingBody(ctx, incomingContentType, next)
+    await parseIncomingBody(ctx, inputContentType, next)
 
     // wait for middleware to bubble up before running the below method
 

--- a/src/middleware/parser.js
+++ b/src/middleware/parser.js
@@ -55,10 +55,7 @@ const parseIncomingBody = async (ctx, inputFormat, next) => {
 }
 
 exports.parseBodyMiddleware = metaData => async (ctx, next) => {
-  const incomingContentType = ctx
-    .get('Content-Type')
-    .split('/')[1]
-    .toUpperCase()
+  const incomingContentType = metaData.transformation.input.toUpperCase()
   const outputContentType = metaData.transformation.output.toUpperCase()
   try {
     // parse incoming body


### PR DESCRIPTION
The expected incoming body type was being set to the value of the incoming content type. This was resulting in routes accepting all content types, as the comparizon between the expected input type and the content type was yielding true all the times. The expected incoming type should be set to the transformation input value from the metadata.

OHM-894