### PR TITLE
OHIE-298 failure rules

### DIFF
--- a/src/middleware/externalRequests.js
+++ b/src/middleware/externalRequests.js
@@ -4,7 +4,7 @@ const axios = require('axios')
 
 const logger = require('../logger')
 
-const validateStatus = allowedStatuses => {
+const validateRequestStatusCode = allowedStatuses => {
   const stringStatuses = allowedStatuses.map(status => {
     return String(status)
   })
@@ -79,7 +79,7 @@ const prepareRequestConfig = requestDetails => {
     requestDetails.allowedStatuses &&
     requestDetails.allowedStatuses.length > 0
   ) {
-    requestOptions.validateStatus = validateStatus(
+    requestOptions.validateStatus = validateRequestStatusCode(
       requestDetails.allowedStatuses
     )
   }

--- a/src/middleware/externalRequests.js
+++ b/src/middleware/externalRequests.js
@@ -4,6 +4,25 @@ const axios = require('axios')
 
 const logger = require('../logger')
 
+const validateStatus = allowedStatuses => {
+  const stringStatuses = allowedStatuses.map(status => {
+    return String(status)
+  })
+  return status => {
+    if (stringStatuses.includes(String(status))) {
+      return true
+    } else {
+      for (let wildCardStatus of stringStatuses) {
+        const validRange = wildCardStatus.match(/.+?(?=xx)/g)
+        if (validRange && String(status).substring(0, 1) == validRange[0]) {
+          return true
+        }
+      }
+    }
+    return false
+  }
+}
+
 const performRequests = requests => {
   return requests.map(requestDetails => {
     return axios(prepareRequestConfig(requestDetails))
@@ -56,6 +75,14 @@ const prepareRequestConfig = requestDetails => {
   const requestOptions = Object.assign({}, requestDetails.config)
   // This step is separated out as in future the URL contained within the config
   // can be manipulated to add URL parameters taken from the body of an incoming request
+  if (
+    requestDetails.allowedStatuses &&
+    requestDetails.allowedStatuses.length > 0
+  ) {
+    requestOptions.validateStatus = validateStatus(
+      requestDetails.allowedStatuses
+    )
+  }
   return requestOptions
 }
 

--- a/tests/unit/externalRequestsTest.js
+++ b/tests/unit/externalRequestsTest.js
@@ -138,7 +138,9 @@ tap.test('External Requests Middleware', {autoend: true}, t => {
       // Example wildcard for 200 range
       const allowedStatuses = ['2xx', 403]
 
-      const validateStatus = externalRequests.__get__('validateStatus')
+      const validateStatus = externalRequests.__get__(
+        'validateRequestStatusCode'
+      )
 
       // The validate status function returns a function that
       // can be used to apply different rules from within the axios config

--- a/tests/unit/externalRequestsTest.js
+++ b/tests/unit/externalRequestsTest.js
@@ -130,4 +130,23 @@ tap.test('External Requests Middleware', {autoend: true}, t => {
       }
     )
   })
+
+  t.test('validateStatus', {autoend: true}, t => {
+    t.test('should resolve wildcard status', t => {
+      t.plan(4)
+
+      // Example wildcard for 200 range
+      const allowedStatuses = ['2xx', 403]
+
+      const validateStatus = externalRequests.__get__('validateStatus')
+
+      // The validate status function returns a function that
+      // can be used to apply different rules from within the axios config
+      const statusValidator = validateStatus(allowedStatuses)
+      t.ok(statusValidator(200))
+      t.ok(statusValidator(299))
+      t.ok(statusValidator(403))
+      t.notOk(statusValidator(300))
+    })
+  })
 })


### PR DESCRIPTION
Users can now define what statuses are valid responses from downstream
services.
Wildcards can be used to declare valid ranges

OHIE-298