### PR TITLE
TRACE-113 Fix docs to match the code

### DIFF
--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -79,7 +79,7 @@ The supported environment variables are listed as follows:
 
   > The OpenHIM requires this default API password to be changed on first login.
 
-- TRUST_SELF_SIGNED - Default: **false**
+- TRUST_SELF_SIGNED - Default: **true**
 
   > Only set this variable to `true` if you are using it in a non-production environment
 
@@ -103,7 +103,7 @@ The supported environment variables are listed as follows:
 
   > Always put child nodes in an array if true; otherwise an array is created only if there is more than one
 
-- VALIDATION_ACCEPT_NULL_VALUES - Default: **true**
+- VALIDATION_ACCEPT_NULL_VALUES - Default: **false**
 
   > This is used to configure the validation middleware to accept `null` values
 


### PR DESCRIPTION
The TRUST_SELF_SIGNED env var defaults to true in the code but the docs
were the ooposite.

The VALIDATION_ACCEPT_NULL_VALUES is also vice versa

It's confusing!!!!

TRACE-113