### PR TITLE
Fixed bug with updating the endpoint state if no extract is supplied

### DIFF
--- a/src/middleware/initiate.js
+++ b/src/middleware/initiate.js
@@ -38,6 +38,10 @@ const extractStateValues = (ctx, extract) => {
     timestamps: ctx.state.allData.timestamps
   }
 
+  if (!extract) {
+    return updatedState
+  }
+
   if (extract.requestBody && Object.keys(extract.requestBody).length > 0) {
     updatedState.requestBody = extractByType('requestBody', extract, allData)
   }


### PR DESCRIPTION
It was thrown an error not being able to access a property of undefined