### PR TITLE
fix the hanging on create and update endpoints

### DIFF
--- a/tests/integration/parser.js
+++ b/tests/integration/parser.js
@@ -13,6 +13,21 @@ tap.test(
   'ParserMiddleware',
   withTestMapperServer(port, async t => {
     t.test(
+      'parser middleware for endpoint creation and update should return error when data sent through is not valid json',
+      async t => {
+        const invalidJson = 'Body'
+
+        const result = await request(`http://localhost:${port}`)
+          .post('/endpoints')
+          .send(invalidJson)
+          .set('Content-Type', 'application/json')
+          .expect(400)
+
+        t.match(result.body.error, /Parsing incoming request body failed/)
+      }
+    )
+
+    t.test(
       'parseBodyMiddleware should accept XML content input and output XML',
       async t => {
         const testEndpoint = {


### PR DESCRIPTION
The endpoints for creating and updating an endpoint were hanging when a request body was not supplied. Logic to fix the hanging has been added in this commit

OHM-1013