### PR TITLE
add logic for validating endpoint patterns

### DIFF
--- a/src/db/models/endpoints.js
+++ b/src/db/models/endpoints.js
@@ -71,6 +71,17 @@ endpointSchema.pre('save', async function (next) {
 
   if (!endpoint.isModified('endpoint')) return next()
 
+  if (
+    endpoint.endpoint.pattern.match(/\/:\//) ||
+    endpoint.endpoint.pattern[endpoint.endpoint.pattern.length - 1] == ':'
+  ) {
+    return next(
+      Error(
+        'Invalid url parameters specified in pattern, url parameter specification format is "/:<PARAMETER_NAME>"'
+      )
+    )
+  }
+
   const regex = /:[^/]\w+/
   const endpointMatchingRegex = new RegExp(
     `^${endpoint.endpoint.pattern.replace(regex, regex.source)}$`

--- a/tests/integration/endpointRoutes.js
+++ b/tests/integration/endpointRoutes.js
@@ -94,6 +94,37 @@ tap.test(
           t.end()
         }
       )
+
+      t.test(
+        'should fail to create when endpoint pattern is invalid',
+        async t => {
+          const testEndpoint = {
+            name: 'Test Endpoint 00',
+            endpoint: {
+              pattern: '/test/name/:/section/:coode',
+              method: 'POST'
+            },
+            transformation: {
+              input: 'XML',
+              output: 'XML'
+            }
+          }
+
+          const result = await request(`http://localhost:${port}`)
+            .post('/endpoints')
+            .send(testEndpoint)
+            .set('Content-Type', 'application/json')
+            .expect(400)
+
+          t.ok(
+            result.body.error.match(
+              'Invalid url parameters specified in pattern, url parameter specification format is "/:<PARAMETER_NAME>"'
+            )
+          )
+
+          t.end()
+        }
+      )
     })
 
     t.test('read endpoint route', {autoend: true}, t => {

--- a/tests/integration/endpointRoutes.js
+++ b/tests/integration/endpointRoutes.js
@@ -96,12 +96,43 @@ tap.test(
       )
 
       t.test(
-        'should fail to create when endpoint pattern is invalid',
+        'should fail to create when endpoint pattern is missing parameter name (internal path)',
         async t => {
           const testEndpoint = {
             name: 'Test Endpoint 00',
             endpoint: {
               pattern: '/test/name/:/section/:coode',
+              method: 'POST'
+            },
+            transformation: {
+              input: 'XML',
+              output: 'XML'
+            }
+          }
+
+          const result = await request(`http://localhost:${port}`)
+            .post('/endpoints')
+            .send(testEndpoint)
+            .set('Content-Type', 'application/json')
+            .expect(400)
+
+          t.ok(
+            result.body.error.match(
+              'Invalid url parameters specified in pattern, url parameter specification format is "/:<PARAMETER_NAME>"'
+            )
+          )
+
+          t.end()
+        }
+      )
+
+      t.test(
+        'should fail to create when endpoint pattern is missing parameter name (end of path)',
+        async t => {
+          const testEndpoint = {
+            name: 'Test Endpoint 01',
+            endpoint: {
+              pattern: '/test/name/section/:',
               method: 'POST'
             },
             transformation: {


### PR DESCRIPTION
Url parameters are now supported and the logic that processes the retrieval of the url parameters (for use in external requests) expects the endpoint pattern to be valid, that is it should have parameter names. patterns like "/path/:/" and "/path/:" will result in the function that handles the request matching failing. The logic that is added in this commit ensures that the url patterns are valid

TRACE-178