### PR TITLE
Allow OpenHIM responses to be passed to OpenHIM

### DIFF
--- a/src/middleware/externalRequests.js
+++ b/src/middleware/externalRequests.js
@@ -368,6 +368,13 @@ const sendMappedObject = (
       if (request.primary) {
         setKoaResponseBodyFromPrimary(ctx, response.body)
 
+        // data has already been transferred and therefor has a content-length defined
+        if (response.headers['transfer-encoding']) {
+          delete response.headers['transfer-encoding']
+        }
+
+        // set main response header to the primary request response
+        ctx.set(response.headers)
         ctx.status = response.status
       } else {
         setKoaResponseBody(ctx, request, response.body)

--- a/src/middleware/externalRequests.js
+++ b/src/middleware/externalRequests.js
@@ -368,7 +368,7 @@ const sendMappedObject = (
       if (request.primary) {
         setKoaResponseBodyFromPrimary(ctx, response.body)
 
-        // data has already been transferred and therefor has a content-length defined
+        // data has already been transferred and therefore has a content-length defined
         if (response.headers['transfer-encoding']) {
           delete response.headers['transfer-encoding']
         }

--- a/src/middleware/initiate.js
+++ b/src/middleware/initiate.js
@@ -144,7 +144,6 @@ exports.initiateContextMiddleware = () => async (ctx, next) => {
       ctx.request.headers &&
       ctx.request.headers[OPENHIM_TRANSACTION_HEADER]
     ) {
-      ctx.response.type = 'application/json+openhim'
       constructOpenhimResponse(ctx, Date.now())
     }
     return

--- a/src/middleware/parser.js
+++ b/src/middleware/parser.js
@@ -69,10 +69,7 @@ const parseOutgoingBody = (ctx, outputFormat) => {
     ctx.request.header &&
     ctx.request.header[OPENHIM_TRANSACTION_HEADER]
   ) {
-    ctx.response.type = 'application/json+openhim'
-    const date = new Date()
-
-    constructOpenhimResponse(ctx, date)
+    constructOpenhimResponse(ctx, Date.now())
   }
 
   logger.info(

--- a/src/openhim.js
+++ b/src/openhim.js
@@ -55,14 +55,25 @@ exports.constructOpenhimResponse = (ctx, responseTimestamp) => {
 
   if (response.type === 'application/json+openhim') {
     if (orchestrations) {
-      if (response.body.orchestrations && Array.isArray(response.body.orchestrations)) {
+      if (
+        response.body &&
+        response.body.orchestrations &&
+        Array.isArray(response.body.orchestrations)
+      ) {
         response.body.orchestrations.unshift(orchestrations)
       }
     }
 
-    ctx.body = JSON.stringify(response.body)
+    ctx.body =
+      typeof response.body === 'string'
+        ? response.body
+        : JSON.stringify(response.body)
     return
   }
+
+  // OpenHIM header not explicity set in response header
+  // Manually set OpenHIM header for processing
+  ctx.response.type = 'application/json+openhim'
 
   if (response) {
     if (response.headers) {

--- a/src/openhim.js
+++ b/src/openhim.js
@@ -53,6 +53,17 @@ exports.constructOpenhimResponse = (ctx, responseTimestamp) => {
   const statusText = ctx.statusText
   const respObject = {}
 
+  if (response.type === 'application/json+openhim') {
+    if (orchestrations) {
+      if (response.body.orchestrations && Array.isArray(response.body.orchestrations)) {
+        response.body.orchestrations.unshift(orchestrations)
+      }
+    }
+
+    ctx.body = JSON.stringify(response.body)
+    return
+  }
+
   if (response) {
     if (response.headers) {
       respObject.headers = response.headers

--- a/src/openhim.js
+++ b/src/openhim.js
@@ -53,6 +53,7 @@ exports.constructOpenhimResponse = (ctx, responseTimestamp) => {
   const statusText = ctx.statusText
   const respObject = {}
 
+  // content-type already defined by final primary request
   if (response.type === 'application/json+openhim') {
     if (orchestrations) {
       if (


### PR DESCRIPTION
If the response from the upstream services is an OpenHIM response, we just need to take the entore body and send it to the OpenHIM for processing

TRACE-179