### PR TITLE
OHIE-431: orchestrations bug

### DIFF
--- a/src/middleware/externalRequests.js
+++ b/src/middleware/externalRequests.js
@@ -115,12 +115,13 @@ const performRequests = (requests, ctx) => {
           ctx.request.headers &&
           ctx.request.headers[OPENHIM_TRANSACTION_HEADER]
         ) {
+          const orchestrationName = `Endpoint Lookup Request: ${ctx.state.metaData.name}: ${requestDetails.id}`
           const orchestration = createOrchestration(
             axiosConfig,
             response,
             reqTimestamp,
             responseTimestamp,
-            requestDetails.id,
+            orchestrationName,
             orchestrationError
           )
 
@@ -409,12 +410,13 @@ const sendMappedObject = (ctx, axiosConfig, request) => {
         ctx.request.headers &&
         ctx.request.headers[OPENHIM_TRANSACTION_HEADER]
       ) {
+        const orchestrationName = `Endpoint Response Request: ${ctx.state.metaData.name}: ${request.id}`
         const orchestration = createOrchestration(
           axiosConfig,
           response,
           reqTimestamp,
           responseTimestamp,
-          request.id,
+          orchestrationName,
           orchestrationError
         )
 

--- a/src/middleware/mapper.js
+++ b/src/middleware/mapper.js
@@ -53,7 +53,7 @@ const createMappedObject = ctx => {
   )
 
   if (ctx.request.headers && ctx.request.headers[OPENHIM_TRANSACTION_HEADER]) {
-    const orchestrationName = 'Mapping'
+    const orchestrationName = `Endpoint Mapping: ${ctx.state.metaData.name}`
     const mappingEndTimestamp = new Date()
     const response = {
       body: output

--- a/src/openhim.js
+++ b/src/openhim.js
@@ -57,29 +57,15 @@ exports.constructOpenhimResponse = (ctx, responseTimestamp) => {
   if (response.type === 'application/json+openhim') {
     if (orchestrations) {
       if (response.body) {
-        // append to routes/orchestrations
-        if (response.body.$push) {
-          if (
-            response.body.$push.orchestrations &&
-            Array.isArray(response.body.$push.orchestrations)
-          ) {
-            response.body.$push.orchestrations = orchestrations.concat(
-              response.body.$push.orchestrations
-            )
-          } else {
-            response.body.$push.orchestrations = orchestrations
-          }
+        if (
+          response.body.orchestrations &&
+          Array.isArray(response.body.orchestrations)
+        ) {
+          response.body.orchestrations = orchestrations.concat(
+            response.body.orchestrations
+          )
         } else {
-          if (
-            response.body.orchestrations &&
-            Array.isArray(response.body.orchestrations)
-          ) {
-            response.body.orchestrations = orchestrations.concat(
-              response.body.orchestrations
-            )
-          } else {
-            response.body.orchestrations = orchestrations
-          }
+          response.body.orchestrations = orchestrations
         }
       }
     }
@@ -125,9 +111,7 @@ exports.constructOpenhimResponse = (ctx, responseTimestamp) => {
     'x-mediator-urn': mediatorConfigJson.urn,
     status: statusText,
     response: respObject,
-    $push: {
-      orchestrations: orchestrations
-    }
+    orchestrations: orchestrations
   }
 
   ctx.body = JSON.stringify(body)

--- a/src/openhim.js
+++ b/src/openhim.js
@@ -61,7 +61,9 @@ exports.constructOpenhimResponse = (ctx, responseTimestamp) => {
         response.body.orchestrations &&
         Array.isArray(response.body.orchestrations)
       ) {
-        response.body.orchestrations.unshift(orchestrations)
+        response.body.orchestrations = orchestrations.concat(
+          response.body.orchestrations
+        )
       }
     }
 

--- a/src/openhim.js
+++ b/src/openhim.js
@@ -56,14 +56,31 @@ exports.constructOpenhimResponse = (ctx, responseTimestamp) => {
   // content-type already defined by final primary request
   if (response.type === 'application/json+openhim') {
     if (orchestrations) {
-      if (
-        response.body &&
-        response.body.orchestrations &&
-        Array.isArray(response.body.orchestrations)
-      ) {
-        response.body.orchestrations = orchestrations.concat(
-          response.body.orchestrations
-        )
+      if (response.body) {
+        // append to routes/orchestrations
+        if (response.body.$push) {
+          if (
+            response.body.$push.orchestrations &&
+            Array.isArray(response.body.$push.orchestrations)
+          ) {
+            response.body.$push.orchestrations = orchestrations.concat(
+              response.body.$push.orchestrations
+            )
+          } else {
+            response.body.$push.orchestrations = orchestrations
+          }
+        } else {
+          if (
+            response.body.orchestrations &&
+            Array.isArray(response.body.orchestrations)
+          ) {
+            response.body.orchestrations = orchestrations.concat(
+              response.body.orchestrations
+            )
+          } else {
+            response.body.orchestrations = orchestrations
+          }
+        }
       }
     }
 
@@ -108,7 +125,9 @@ exports.constructOpenhimResponse = (ctx, responseTimestamp) => {
     'x-mediator-urn': mediatorConfigJson.urn,
     status: statusText,
     response: respObject,
-    orchestrations: orchestrations
+    $push: {
+      orchestrations: orchestrations
+    }
   }
 
   ctx.body = JSON.stringify(body)

--- a/tests/integration/externalRequests.js
+++ b/tests/integration/externalRequests.js
@@ -797,7 +797,7 @@ tap.test(
               )
               t.equals(response.body.status, 'Successful')
               t.equals(
-                response.body.orchestrations[0].request.path,
+                response.body.$push.orchestrations[0].request.path,
                 '/fhir/Patient/pre12345post/_history'
               )
             })

--- a/tests/integration/externalRequests.js
+++ b/tests/integration/externalRequests.js
@@ -797,7 +797,7 @@ tap.test(
               )
               t.equals(response.body.status, 'Successful')
               t.equals(
-                response.body.$push.orchestrations[0].request.path,
+                response.body.orchestrations[0].request.path,
                 '/fhir/Patient/pre12345post/_history'
               )
             })

--- a/tests/integration/integration.js
+++ b/tests/integration/integration.js
@@ -197,7 +197,7 @@ tap.test(
                 response.body.response.body,
                 '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<root/>'
               )
-              t.equals(response.body.$push.orchestrations.length, 5)
+              t.equals(response.body.orchestrations.length, 5)
               t.equals(response.status, 201)
             })
         }
@@ -334,7 +334,7 @@ tap.test(
                 response.body.response.body,
                 '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<root/>'
               )
-              t.equals(response.body.$push.orchestrations.length, 5)
+              t.equals(response.body.orchestrations.length, 5)
               t.equals(response.status, 201)
             })
         }

--- a/tests/integration/integration.js
+++ b/tests/integration/integration.js
@@ -197,7 +197,7 @@ tap.test(
                 response.body.response.body,
                 '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<root/>'
               )
-              t.equals(response.body.orchestrations.length, 4)
+              t.equals(response.body.$push.orchestrations.length, 5)
               t.equals(response.status, 201)
             })
         }
@@ -334,7 +334,7 @@ tap.test(
                 response.body.response.body,
                 '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<root/>'
               )
-              t.equals(response.body.orchestrations.length, 4)
+              t.equals(response.body.$push.orchestrations.length, 5)
               t.equals(response.status, 201)
             })
         }

--- a/tests/integration/mapper.js
+++ b/tests/integration/mapper.js
@@ -448,13 +448,13 @@ tap.test(
 
         t.ok(result.body['x-mediator-urn'])
         t.equals(result.body.status, 'Successful')
-        t.equal(result.body.$push.orchestrations.length, 3)
+        t.equal(result.body.orchestrations.length, 3)
         t.equal(
-          result.body.$push.orchestrations[1].name,
+          result.body.orchestrations[1].name,
           'Endpoint Validation: Mapping Test Endpoint 1 (success)'
         )
         t.equal(
-          result.body.$push.orchestrations[2].name,
+          result.body.orchestrations[2].name,
           'Endpoint Mapping: Mapping Test Endpoint 1 (success)'
         )
         t.end()

--- a/tests/integration/mapper.js
+++ b/tests/integration/mapper.js
@@ -448,8 +448,15 @@ tap.test(
 
         t.ok(result.body['x-mediator-urn'])
         t.equals(result.body.status, 'Successful')
-        t.equal(result.body.orchestrations.length, 2)
-        t.equal(result.body.orchestrations[1].name, 'Mapping')
+        t.equal(result.body.$push.orchestrations.length, 3)
+        t.equal(
+          result.body.$push.orchestrations[1].name,
+          'Endpoint Validation: Mapping Test Endpoint 1 (success)'
+        )
+        t.equal(
+          result.body.$push.orchestrations[2].name,
+          'Endpoint Mapping: Mapping Test Endpoint 1 (success)'
+        )
         t.end()
       }
     )

--- a/tests/unit/mapper.js
+++ b/tests/unit/mapper.js
@@ -246,7 +246,7 @@ tap.test('Mapper', {autoend: true}, t => {
       createMappedObject(ctx)
 
       t.equals(ctx.orchestrations.length, 1)
-      t.equals(ctx.orchestrations[0].name, 'Mapping')
+      t.equals(ctx.orchestrations[0].name, 'Endpoint Mapping: Testing endpoint')
       t.deepEqual(ctx.orchestrations[0].response.body, JSON.stringify(expected))
       t.end()
     })
@@ -295,7 +295,10 @@ tap.test('Mapper', {autoend: true}, t => {
         createMappedObject(ctx)
 
         t.equals(ctx.orchestrations.length, 1)
-        t.equals(ctx.orchestrations[0].name, 'Mapping')
+        t.equals(
+          ctx.orchestrations[0].name,
+          'Endpoint Mapping: Testing endpoint'
+        )
         t.deepEqual(
           ctx.orchestrations[0].response.body,
           JSON.stringify(expected)

--- a/tests/unit/openhim.js
+++ b/tests/unit/openhim.js
@@ -97,9 +97,7 @@ tap.test('constructOpenhimResponse()', {autoend: true}, t => {
         body: JSON.stringify(body),
         timestamp
       },
-      $push: {
-        orchestrations: orchestrations
-      }
+      orchestrations: orchestrations
     }
 
     constructOpenhimResponse(ctx, timestamp)

--- a/tests/unit/openhim.js
+++ b/tests/unit/openhim.js
@@ -97,12 +97,14 @@ tap.test('constructOpenhimResponse()', {autoend: true}, t => {
         body: JSON.stringify(body),
         timestamp
       },
-      orchestrations: orchestrations
+      $push: {
+        orchestrations: orchestrations
+      }
     }
 
     constructOpenhimResponse(ctx, timestamp)
 
-    t.deepEqual(expectedResponse, JSON.parse(ctx.body))
+    t.deepEqual(JSON.parse(ctx.body), expectedResponse)
     t.end()
   })
 })


### PR DESCRIPTION
This fixes a bug where orchestrations were being replaced instead of added to the existing array
Using "unshift" on an array is for adding individual items to the array (comma separated), but we need to append the entire array
"Concat" adds an existing array to antoher array without having to loop through each array item and then using "unshift"

https://www.w3schools.com/jsref/jsref_unshift.asp
https://www.w3schools.com/jsref/jsref_concat_array.asp

Edit
---------------------
Also updated the orchestration name to be a bit more descriptive.
Added in a orchestration for validation middleware