### PR TITLE
Update orchestration docs forEach info

### DIFF
--- a/docs/docs/gettingStarted/endpoints.md
+++ b/docs/docs/gettingStarted/endpoints.md
@@ -560,6 +560,7 @@ There are two types of external requests, the `lookup` and the `response`. Query
     "lookup": [
       {
         "id": "test",
+        "forwardExistingRequestBody": true, // If you need access to the payload this field MUST be specified
         "forEach": {
           "items": "payload.entry",
           "concurrency": "2" // if not specified defaults to 1


### PR DESCRIPTION
The forwardExistingRequestBody field must be set to true if you need to
access the incoming request payload (within items)
If the field is left out the request body will be set to `null`

DSC19-25