### PR TITLE
WIP: Add unique index on endpoint method and pattern combo

### DIFF
--- a/tests/integration/endpointRoutes.js
+++ b/tests/integration/endpointRoutes.js
@@ -88,7 +88,7 @@ tap.test(
 
           t.ok(
             result.body.error.match(
-              /Duplicate error: regex created from endpoint pattern /
+              /Duplicate error: HTTP method and regex created from endpoint pattern /
             )
           )
           t.end()

--- a/tests/unit/dbService.js
+++ b/tests/unit/dbService.js
@@ -139,7 +139,8 @@ tap.test('Database interactions', {autoend: true}, t => {
         const testEndpointConfig = {
           name: 'test 1',
           endpoint: {
-            pattern: '/test'
+            pattern: '/test',
+            method: 'POST'
           },
           transformation: {
             input: 'JSON',
@@ -160,7 +161,8 @@ tap.test('Database interactions', {autoend: true}, t => {
         const samePatternTestEndpointConfig = {
           name: 'test 2',
           endpoint: {
-            pattern: '/test'
+            pattern: '/test',
+            method: 'POST'
           },
           transformation: {
             input: 'JSON',
@@ -176,7 +178,7 @@ tap.test('Database interactions', {autoend: true}, t => {
           .catch(error => {
             t.equals(
               error.message,
-              'Duplicate error: regex created from endpoint pattern /test for matching requests already exists'
+              'Duplicate error: HTTP method and regex created from endpoint pattern /test for matching requests already exists'
             )
           })
       }


### PR DESCRIPTION
The mapping should allow multiple endpoints to be created with the same
pattern if they work on different request methods. This is needed as
logic for:
GET /test vs POST /test
PUT /test/:id vs DELETE /test/:id
Are completely different yet their url path patterns are the same.
The mapping mediator already caters to adding routes per HTTP Method

DEB-8