### PR TITLE
DSC19-96 Ensure all response requests contain the mapped data

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ To register as a mediator, you will need the following environment variables:
 - `MONGO_URL=mongodb://mapper-mongo-1:27017,mapper-mongo-2:27017,mapper-mongo-3:27017/mapping-mediator?replicaSet=mapper-mongo-set`
 
 ```sh
-docker run -e OPENHIM_URL=https://openhim-core:8080 -e OPENHIM_PASSWORD={openhim_password} -e MONGO_URL=mongodb://mapper-mongo-1:27017,mapper-mongo-2:27017,mapper-mongo-3:27017/mapping-mediator?replicaSet=mapper-mongo-set --network mapper-cluster-network --name mapper -d jembi/openhim-mediator-mapping:v2.3.0
+docker run -e OPENHIM_URL=https://openhim-core:8080 -e OPENHIM_PASSWORD={openhim_password} -e MONGO_URL=mongodb://mapper-mongo-1:27017,mapper-mongo-2:27017,mapper-mongo-3:27017/mapping-mediator?replicaSet=mapper-mongo-set --network mapper-cluster-network --name mapper -d jembi/openhim-mediator-mapping:v2.3.1
 ```
 
 > Note: **The Mapping Mediator is not exposed to your local machine in this case**. All requests would need to go through the OpenHIM. To expose the Mapping Mediator port to your local machine include the following flag in your run command: `-p 3003:3003`

--- a/docs/docs/gettingStarted/setup.md
+++ b/docs/docs/gettingStarted/setup.md
@@ -39,7 +39,7 @@ Zipped repository:
 wget https://github.com/jembi/openhim-mediator-mapping/archive/master.zip
 ```
 
-Zipped release version. Tagged releases can be downloaded by executing the below command, and replacing the <RELEASE_VERSION> placeholder with an actual [release tag](https://github.com/jembi/openhim-mediator-mapping/releases): E.g `v2.3.0`
+Zipped release version. Tagged releases can be downloaded by executing the below command, and replacing the <RELEASE_VERSION> placeholder with an actual [release tag](https://github.com/jembi/openhim-mediator-mapping/releases): E.g `v2.3.1`
 
 ```sh
 wget https://github.com/jembi/openhim-mediator-mapping/releases/download/<RELEASE_VERSION>/build.openhim-mediator-mapping.<RELEASE_VERSION>.zip

--- a/mediatorConfig.json
+++ b/mediatorConfig.json
@@ -1,6 +1,6 @@
 {
   "urn": "urn:mediator:generic_mapper",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "name": "Mapping Mediator",
   "description": "Generic OpenHIM Mapping Mediator",
   "endpoints": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhim-mediator-generic-mapper",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Generic Mapping Mediator",
   "repository": "git@github.com:jembi/openhim-mediator-mapping.git",
   "author": "Jembi Health Systems NPC",

--- a/tests/unit/externalRequests.js
+++ b/tests/unit/externalRequests.js
@@ -431,6 +431,7 @@ tap.test('External Requests', {autoend: true}, t => {
               }
             }
           },
+          body: {},
           request: {}
         }
         await prepareResponseRequests(ctx)


### PR DESCRIPTION
Previously, if there were multiple response requests only the first
response would contain data - the others would be empty objects

This was due to a logic error associated with the array responses as in
that case the data did need to be cleared between requests

DSC19-96