### PR TITLE
Add a header to indicate the origin of the request/response in order …

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -14,6 +14,7 @@ exports.MONGOOSE_STRING_TIMESTAMP_REGEX =
   /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])\.([0-9]+)?(Z)?$/
 
 exports.OPENHIM_TRANSACTION_HEADER = 'x-openhim-transactionid'
+exports.ORIGIN_HEADER = 'x-origin'
 
 // Only allows the values from 100 to 599 which spans the possible valid HTTP statuses
 exports.HTTP_STATUS_REGEX = /^[1-5]{1}\d\d$/

--- a/src/middleware/externalRequests.js
+++ b/src/middleware/externalRequests.js
@@ -4,7 +4,7 @@ const axios = require('axios')
 const {DateTime} = require('luxon')
 
 const logger = require('../logger')
-const {OPENHIM_TRANSACTION_HEADER} = require('../constants')
+const {OPENHIM_TRANSACTION_HEADER, ORIGIN_HEADER} = require('../constants')
 
 const {createOrchestration} = require('../orchestrations')
 const {extractValueFromObject, makeQuerablePromise} = require('../util')
@@ -39,7 +39,8 @@ const performLookupRequest = async (ctx, requestDetails) => {
     requestDetails.config.headers = Object.assign(
       {
         [OPENHIM_TRANSACTION_HEADER]:
-          ctx.request.headers[OPENHIM_TRANSACTION_HEADER]
+          ctx.request.headers[OPENHIM_TRANSACTION_HEADER],
+        [ORIGIN_HEADER]: 'Mapper'
       },
       requestDetails.config.headers
     )
@@ -394,7 +395,8 @@ const performResponseRequests = (ctx, requests) => {
         request.config.headers = Object.assign(
           {
             [OPENHIM_TRANSACTION_HEADER]:
-              ctx.request.headers[OPENHIM_TRANSACTION_HEADER]
+              ctx.request.headers[OPENHIM_TRANSACTION_HEADER],
+            [ORIGIN_HEADER]: 'Mapper'
           },
           request.config.headers
         )

--- a/src/middleware/parser.js
+++ b/src/middleware/parser.js
@@ -8,7 +8,8 @@ const logger = require('../logger')
 
 const {
   ALLOWED_CONTENT_TYPES,
-  OPENHIM_TRANSACTION_HEADER
+  OPENHIM_TRANSACTION_HEADER,
+  ORIGIN_HEADER
 } = require('../constants')
 const {createOrchestration, setStatusText} = require('../orchestrations')
 const {constructOpenhimResponse} = require('../openhim')
@@ -65,7 +66,8 @@ const parseOutgoingBody = (ctx, outputFormat) => {
   if (
     ctx.request &&
     ctx.request.headers &&
-    ctx.request.headers[OPENHIM_TRANSACTION_HEADER]
+    ctx.request.headers[OPENHIM_TRANSACTION_HEADER] &&
+    !ctx.request.headers[ORIGIN_HEADER]
   ) {
     constructOpenhimResponse(ctx, Date.now())
   }


### PR DESCRIPTION
…to form the body in a more readable manner

Currently the recursion of the mediator causes the response to return a body that is very large and difficult to read
OHIE-535