### PR TITLE
Tb 181 fix error handling

### DIFF
--- a/docs/docs/gettingStarted/endpoints.md
+++ b/docs/docs/gettingStarted/endpoints.md
@@ -334,7 +334,8 @@ Below is an extract of some request orchestrations.
             "Content-Type": "application/json",
             "Authorization": "Basic YWRtaW46ZGlzdHJpY3Q="
           }
-        }
+        },
+        "fhirResponse": true
       }
     ],
     "response": [
@@ -353,7 +354,7 @@ Below is an extract of some request orchestrations.
 }
 ```
 
-In the example above, the lookup request gets facility data from DHIS2. That data would then be mapped (schema not shown for brevity) and the output data sent to a FHIR server. These requests can include query and url parameters which can be extracted from incoming data. Chaining together endpoint calls using this orchestration mechanism can lead to very complex logic being implemented.
+In the example above, the lookup request gets facility data from DHIS2. That data would then be mapped (schema not shown for brevity) and the output data sent to a FHIR server. These requests can include query and url parameters which can be extracted from incoming data. Chaining together endpoint calls using this orchestration mechanism can lead to very complex logic being implemented. The `fhirResponse` parameter in the `lookup` ensures that the error is returned in fhir format (an OperationOutcome resource).
 
 There are two types of external requests, the `lookup` and the `response`. Query and url parameters for the external request can be dynamically populated
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhim-mediator-generic-mapper",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "Generic Mapping Mediator",
   "repository": "git@github.com:jembi/openhim-mediator-mapping.git",
   "author": "Jembi Health Systems NPC",

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,7 +8,7 @@ exports.DEFAULT_ENDPOINT_METHOD = 'POST'
 
 // This regex only permits strings with URI safe characters.
 // It also prevents the path starting with the string 'endpoints' and 'uptime' as this is a reserved api path
-exports.MIDDLEWARE_PATH_REGEX = /^(?!\/endpoints|\/uptime)\/[\d\w-._~/:]+$/
+exports.MIDDLEWARE_PATH_REGEX = /^(?!\/endpoints|\/uptime)\/[\d\w-$._~/:]+$/
 
 exports.MONGOOSE_STRING_TIMESTAMP_REGEX =
   /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])\.([0-9]+)?(Z)?$/

--- a/src/db/models/endpoints.js
+++ b/src/db/models/endpoints.js
@@ -71,7 +71,8 @@ const endpointSchema = new mongoose.Schema(
             concurrency: Number
           },
           config: Config,
-          allowedStatuses: []
+          allowedStatuses: [],
+          fhirResponse: Boolean
         }
       ],
       response: [
@@ -82,7 +83,8 @@ const endpointSchema = new mongoose.Schema(
             concurrency: Number
           },
           config: Config,
-          kafkaProducerTopic: String
+          kafkaProducerTopic: String,
+          fhirResponse: Boolean
         }
       ]
     },

--- a/src/db/models/endpoints.js
+++ b/src/db/models/endpoints.js
@@ -83,8 +83,7 @@ const endpointSchema = new mongoose.Schema(
             concurrency: Number
           },
           config: Config,
-          kafkaProducerTopic: String,
-          fhirResponse: Boolean
+          kafkaProducerTopic: String
         }
       ]
     },

--- a/src/middleware/externalRequests.js
+++ b/src/middleware/externalRequests.js
@@ -568,11 +568,6 @@ const performResponseRequest = (ctx, body, requestDetails) => {
       })
   }
 
-  // Enables us to respond in fhir format
-  if (requestDetails.fhirResponse) {
-    ctx.fhirResponse = true
-  }
-
   const reqTimestamp = DateTime.utc().toISO()
   let response, orchestrationError, responseTimestamp
 

--- a/src/middleware/externalRequests.js
+++ b/src/middleware/externalRequests.js
@@ -113,8 +113,16 @@ const performLookupRequest = async (ctx, requestDetails) => {
           error.response.status
             ? ctx.state.allData.state.currentLookupHttpStatus
             : error.response.status
+
+        // Enables us to respond in fhir format
+        if (requestDetails.fhirResponse) {
+          ctx.fhirResponse = true
+          throw error.response.data
+        }
         throw new Error(
-          `Incorrect status code ${error.response.status}. ${error.response.data.message}`
+          `Incorrect status code ${error.response.status}. ${JSON.stringify(
+            error.response.data
+          )}`
         )
       } else if (error.request) {
         ctx.state.allData.state.currentLookupNetworkError = true
@@ -258,7 +266,7 @@ const prepareLookupRequests = ctx => {
         ctx.state.allData.lookupRequests = incomingData
       })
       .catch(error => {
-        throw new Error(`Rejected Promise: ${error}`)
+        throw error
       })
   }
   logger.debug(
@@ -558,6 +566,11 @@ const performResponseRequest = (ctx, body, requestDetails) => {
       .catch(err => {
         ctx.body = err.message
       })
+  }
+
+  // Enables us to respond in fhir format
+  if (requestDetails.fhirResponse) {
+    ctx.fhirResponse = true
   }
 
   const reqTimestamp = DateTime.utc().toISO()

--- a/src/middleware/parser.js
+++ b/src/middleware/parser.js
@@ -12,6 +12,7 @@ const {
 } = require('../constants')
 const {createOrchestration, setStatusText} = require('../orchestrations')
 const {constructOpenhimResponse} = require('../openhim')
+const {formatErrorToFhir} = require('../util')
 
 const xmlBuilder = new xml2js.Builder()
 
@@ -197,10 +198,15 @@ exports.parseBodyMiddleware = () => async (ctx, next) => {
   } catch (error) {
     ctx.status = ctx.statusCode ? ctx.statusCode : 400
     ctx.statusText = 'Failed'
-    logger.error(error.message)
+    logger.error(error)
 
     // parse outgoing body
     ctx.body = {error: error.message}
+
+    // For endpoints that expect fhir responses
+    if (ctx.fhirResponse) {
+      formatErrorToFhir(error, ctx)
+    }
     return parseOutgoingBody(ctx, outputContentType)
   }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -121,3 +121,21 @@ exports.makeQuerablePromise = promise => {
 
   return result
 }
+
+// This enables us to respond with a fhir formatted error (an operation outcome resource)
+exports.formatErrorToFhir = (error, ctx) => {
+  if (!error.resourceType || error.resourceType != 'OperationOutcome') {
+    ctx.body = {
+      resourceType: 'OperationOutcome',
+      issue: [
+        {
+          severity: 'error',
+          code: 'processsing',
+          diagnostic: error
+        }
+      ]
+    }
+  } else {
+    ctx.body = error
+  }
+}

--- a/tests/integration/endpointRoutes.js
+++ b/tests/integration/endpointRoutes.js
@@ -42,8 +42,8 @@ tap.test(
           .set('Content-Type', 'application/json')
           .expect(201)
 
-        t.equals(result.body.name, testEndpoint.name)
-        t.equals(result.body.pattern, testEndpoint.pattern)
+        t.equal(result.body.name, testEndpoint.name)
+        t.equal(result.body.pattern, testEndpoint.pattern)
         t.end()
       })
 
@@ -168,7 +168,7 @@ tap.test(
             .get(`/endpoints/${endpointId}`)
             .expect(400)
 
-          t.equals(
+          t.equal(
             result.body.error,
             'Retrieving of endpoint failed: Endpoint ID supplied in url is invalid'
           )
@@ -185,7 +185,7 @@ tap.test(
             .get(`/endpoints/${endpointId}`)
             .expect(404)
 
-          t.equals(
+          t.equal(
             result.body.error,
             `Endpoint with ID ${endpointId} does not exist`
           )
@@ -215,8 +215,8 @@ tap.test(
           .get(`/endpoints/${endpoint.body._id}`)
           .expect(200)
 
-        t.equals(result.body.name, testEndpoint.name)
-        t.equals(result.body.pattern, testEndpoint.pattern)
+        t.equal(result.body.name, testEndpoint.name)
+        t.equal(result.body.pattern, testEndpoint.pattern)
         t.end()
       })
     })
@@ -304,9 +304,9 @@ tap.test(
           .get(`/endpoints?_id=${endpoint.body._id}`)
           .expect(200)
 
-        t.equals(result.body.length, 1)
-        t.equals(result.body[0].name, testEndpoint.name)
-        t.equals(result.body[0].pattern, testEndpoint.pattern)
+        t.equal(result.body.length, 1)
+        t.equal(result.body[0].name, testEndpoint.name)
+        t.equal(result.body[0].pattern, testEndpoint.pattern)
         t.end()
       })
     })
@@ -358,7 +358,7 @@ tap.test(
             .set('Content-Type', 'application/json')
             .expect(404)
 
-          t.equals(
+          t.equal(
             result.body.error,
             `Endpoint with ID ${endpointId} does not exist`
           )
@@ -396,7 +396,7 @@ tap.test(
           .set('Content-Type', 'application/json')
           .expect(200)
 
-        t.deepEqual(result.body.transformation, update.transformation)
+        t.same(result.body.transformation, update.transformation)
         t.end()
       })
     })
@@ -424,7 +424,7 @@ tap.test(
             .delete(`/endpoints/${endpointId}`)
             .expect(404)
 
-          t.equals(
+          t.equal(
             result.body.error,
             `Endpoint with ID '${endpointId}' does not exist`
           )
@@ -454,7 +454,7 @@ tap.test(
           .delete(`/endpoints/${endpoint.body._id}`)
           .expect(200)
 
-        t.deepEqual(
+        t.same(
           result.body.message,
           `Endpoint with ID '${endpoint.body._id}' deleted`
         )

--- a/tests/integration/externalRequests.js
+++ b/tests/integration/externalRequests.js
@@ -103,7 +103,7 @@ tap.test(
           .send(requestData)
           .set('Content-Type', 'application/json')
           .expect(response => {
-            t.deepEquals(response.body, {fhirPatient, fhirObservation})
+            t.same(response.body, {fhirPatient, fhirObservation})
           })
       })
 
@@ -139,7 +139,7 @@ tap.test(
           server.on('request', async (req, res) => {
             if (req.method === 'POST' && req.url === '/Patient') {
               req.on('data', chunk => {
-                t.equals(chunk.toString(), JSON.stringify(requestBody))
+                t.equal(chunk.toString(), JSON.stringify(requestBody))
               })
               t.pass()
               res.writeHead(200, {'Content-Type': 'application/json'})
@@ -207,7 +207,7 @@ tap.test(
             .send(requestBody)
             .set('Content-Type', 'application/json')
             .expect(response => {
-              t.deepEquals(response.body, {fhirPatient, fhirObservation})
+              t.same(response.body, {fhirPatient, fhirObservation})
             })
         }
       )
@@ -325,7 +325,7 @@ tap.test(
             .send(requestData)
             .set('Content-Type', 'application/json')
             .expect(response => {
-              t.deepEquals(response.body, {fhirPatient, fhirObservation})
+              t.same(response.body, {fhirPatient, fhirObservation})
             })
         }
       )
@@ -402,8 +402,8 @@ tap.test(
           .send(requestData)
           .set('Content-Type', 'application/json')
           .expect(response => {
-            t.equals(response.status, 201)
-            t.deepEquals(response.body, fhirPatientResponse)
+            t.equal(response.status, 201)
+            t.same(response.body, fhirPatientResponse)
           })
       })
 
@@ -488,8 +488,8 @@ tap.test(
             .send(requestData)
             .set('Content-Type', 'application/json')
             .expect(response => {
-              t.equals(response.status, 200)
-              t.deepEquals(response.body, fhirPatient)
+              t.equal(response.status, 200)
+              t.same(response.body, fhirPatient)
             })
         }
       )
@@ -549,10 +549,10 @@ tap.test(
           .send(requestData)
           .set('Content-Type', 'application/json')
           .expect(response => {
-            t.equals(response.status, 418)
-            t.deepEquals(
+            t.equal(response.status, 418)
+            t.same(
               response.body.error,
-              `Rejected Promise: Error: Incorrect status code 418. I'm a teapot`
+              `Incorrect status code 418. {"message":"I'm a teapot"}`
             )
           })
       })
@@ -615,8 +615,8 @@ tap.test(
           .send(requestData)
           .set('Content-Type', 'application/json')
           .expect(response => {
-            t.equals(response.status, 504)
-            t.deepEquals(response.body.message, 'Gateway Timeout')
+            t.equal(response.status, 504)
+            t.same(response.body.message, 'Gateway Timeout')
           })
       })
 
@@ -701,8 +701,8 @@ tap.test(
             .send(requestData)
             .set('Content-Type', 'application/json')
             .expect(response => {
-              t.equals(response.status, 200)
-              t.deepEquals(response.body, fhirPatient)
+              t.equal(response.status, 200)
+              t.same(response.body, fhirPatient)
             })
         }
       )
@@ -790,13 +790,13 @@ tap.test(
             // forces a mediator response
             .set('x-openhim-transactionid', '123')
             .expect(response => {
-              t.equals(response.status, 200)
-              t.equals(
+              t.equal(response.status, 200)
+              t.equal(
                 response.body['x-mediator-urn'],
                 'urn:mediator:generic_mapper'
               )
-              t.equals(response.body.status, 'Successful')
-              t.equals(
+              t.equal(response.body.status, 'Successful')
+              t.equal(
                 response.body.orchestrations[0].request.path,
                 '/fhir/Patient/pre12345post/_history'
               )
@@ -868,7 +868,7 @@ tap.test(
             .send(requestData)
             .set('Content-Type', 'application/json')
             .expect(response => {
-              t.deepEquals(response.body, {
+              t.same(response.body, {
                 fhirPatient: [{id: 1}, {id: 2}, {id: 3}]
               })
             })
@@ -951,7 +951,7 @@ tap.test(
             .send(requestData)
             .set('Content-Type', 'application/json')
             .expect(response => {
-              t.deepEquals(response.body, {
+              t.same(response.body, {
                 fhirPatient: [
                   {id: 1},
                   {id: 2},
@@ -1023,10 +1023,10 @@ tap.test(
             .send(requestData)
             .set('Content-Type', 'application/json')
             .expect(response => {
-              t.equals(response.status, 400)
-              t.deepEquals(
+              t.equal(response.status, 400)
+              t.same(
                 response.body.error,
-                "Rejected Promise: Error: forEach.items could not be found at the specified path or the resolved value isn't an array"
+                "forEach.items could not be found at the specified path or the resolved value isn't an array"
               )
             })
         }
@@ -1103,7 +1103,7 @@ tap.test(
             .send(requestData)
             .set('Content-Type', 'application/json')
             .expect(response => {
-              t.deepEquals(response.body, {
+              t.same(response.body, {
                 fhirPatient: [{id: 111}, {id: 222}, {id: 333}]
               })
             })
@@ -1160,8 +1160,8 @@ tap.test(
             .send(requestData)
             .set('Content-Type', 'application/json')
             .expect(response => {
-              t.equals(response.status, 400)
-              t.deepEquals(
+              t.equal(response.status, 400)
+              t.same(
                 response.body.error,
                 "Rejected Promise: Error: forEach.items could not be found at the specified path or the resolved value isn't an array"
               )
@@ -1237,7 +1237,7 @@ tap.test(
             .send(requestData)
             .set('Content-Type', 'application/json')
             .expect(response => {
-              t.deepEquals(response.body, {
+              t.same(response.body, {
                 fhirPatient: [{id: 111}, {id: 222}, {id: 333}]
               })
             })
@@ -1308,7 +1308,7 @@ tap.test(
             .send(requestData)
             .set('Content-Type', 'application/json')
             .expect(response => {
-              t.deepEquals(response.body, {id: 111})
+              t.same(response.body, {id: 111})
             })
         }
       )
@@ -1391,7 +1391,7 @@ tap.test(
             .send(requestData)
             .set('Content-Type', 'application/json')
             .expect(response => {
-              t.deepEquals(response.body, {
+              t.same(response.body, {
                 'fhirPatient-1': {id: 111},
                 'fhirPatient-2': {id: 111}
               })
@@ -1468,7 +1468,7 @@ tap.test(
             .set('Content-Type', 'application/json')
             .set('requesting_client', requesting_client)
             .expect(response => {
-              t.deepEquals(
+              t.same(
                 response.body,
                 Object.assign({}, {fhirPatient, requesting_client, client_id})
               )

--- a/tests/integration/externalRequests.js
+++ b/tests/integration/externalRequests.js
@@ -626,7 +626,7 @@ tap.test(
       t.test(
         'requestMiddleware should fail lookup request and return fhir response 2',
         async t => {
-          t.plan(5)
+          t.plan(3)
           server.on('request', async (req, res) => {
             if (req.method === 'GET' && req.url === '/Patient') {
               t.pass()

--- a/tests/integration/externalRequests.js
+++ b/tests/integration/externalRequests.js
@@ -623,6 +623,70 @@ tap.test(
         }
       )
 
+      t.test(
+        'requestMiddleware should fail lookup request and return fhir response 2',
+        async t => {
+          t.plan(5)
+          server.on('request', async (req, res) => {
+            if (req.method === 'GET' && req.url === '/Patient') {
+              t.pass()
+              res.writeHead(418, {'Content-Type': 'application/json'})
+              res.end(JSON.stringify({resourceType: 'OperationOutcome'}))
+              return
+            }
+            res.writeHead(404)
+            res.end()
+            return
+          })
+
+          const testEndpoint = {
+            name: 'External Request Test Endpoint 24 - fhir error',
+            endpoint: {
+              pattern: '/externalRequestTestFhir24'
+            },
+            transformation: {
+              input: 'JSON',
+              output: 'JSON'
+            },
+            requests: {
+              lookup: [
+                {
+                  id: 'fhirPatient',
+                  config: {
+                    method: 'get',
+                    url: `http://localhost:${mockServerPort}/Patient`
+                  },
+                  fhirResponse: true
+                }
+              ]
+            }
+          }
+
+          await request(`http://localhost:${testMapperPort}`)
+            .post('/endpoints')
+            .send(testEndpoint)
+            .set('Content-Type', 'application/json')
+            .expect(201)
+
+          // The mongoDB endpoint collection change listeners may take a few milliseconds to update the endpoint cache.
+          // This wouldn't be a problem in the normal use case as a user would not create an endpoint and
+          // immediately start posting to it within a few milliseconds. Therefore this timeout here should be fine...
+          await sleep(100)
+
+          // The mapper currently only accepts POSTs
+          const requestData = {}
+
+          await request(`http://localhost:${testMapperPort}`)
+            .post('/externalRequestTestFhir24')
+            .send(requestData)
+            .set('Content-Type', 'application/json')
+            .expect(response => {
+              t.equal(response.status, 418)
+              t.equal(response.body.resourceType, 'OperationOutcome')
+            })
+        }
+      )
+
       t.test('requestMiddleware should fail response request', async t => {
         t.plan(3)
         server.on('request', async (req, res) => {

--- a/tests/integration/integration.js
+++ b/tests/integration/integration.js
@@ -39,7 +39,7 @@ tap.test(
             }
             if (req.method == 'POST' && req.url === '/api') {
               req.on('data', chunk => {
-                t.equals(
+                t.equal(
                   chunk.toString(),
                   `{"sex":"U","age":${Math.floor(
                     (Date.now() - new Date('1945-09-03')) / 31556952000
@@ -199,12 +199,12 @@ tap.test(
             .set('Content-Type', 'application/json')
             .set(OPENHIM_TRANSACTION_HEADER, 'requestUUID')
             .expect(response => {
-              t.equals(
+              t.equal(
                 response.body.response.body,
                 '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<root/>'
               )
-              t.equals(response.body.orchestrations.length, 5)
-              t.equals(response.status, 201)
+              t.equal(response.body.orchestrations.length, 5)
+              t.equal(response.status, 201)
             })
         }
       )
@@ -229,7 +229,7 @@ tap.test(
             }
             if (req.method == 'POST' && req.url === '/api') {
               req.on('data', chunk => {
-                t.equals(
+                t.equal(
                   chunk.toString(),
                   '{"sex":"U","nationality":"South Africa"}'
                 )
@@ -341,12 +341,12 @@ tap.test(
             .get('/integrationTest2')
             .set(OPENHIM_TRANSACTION_HEADER, 'requestUUID')
             .expect(response => {
-              t.equals(
+              t.equal(
                 response.body.response.body,
                 '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<root/>'
               )
-              t.equals(response.body.orchestrations.length, 5)
-              t.equals(response.status, 201)
+              t.equal(response.body.orchestrations.length, 5)
+              t.equal(response.status, 201)
             })
         }
       )

--- a/tests/integration/mapper.js
+++ b/tests/integration/mapper.js
@@ -72,7 +72,7 @@ tap.test(
           .set('Content-Type', 'application/json')
           .expect(200)
 
-        t.deepEqual(result.body, requestData)
+        t.same(result.body, requestData)
         t.end()
       }
     )
@@ -134,7 +134,7 @@ tap.test(
         .set('Content-Type', 'application/fhir+json')
         .expect(200)
 
-      t.deepEqual(result.body, requestData)
+      t.same(result.body, requestData)
       t.equal(result.headers['content-type'], 'application/fhir+json')
       t.end()
     })
@@ -196,7 +196,7 @@ tap.test(
         .set('Content-Type', 'application/json+openhim')
         .expect(200)
 
-      t.deepEqual(result.body, requestData)
+      t.same(result.body, requestData)
       t.equal(result.headers['content-type'], 'application/json+openhim')
       t.end()
     })
@@ -290,7 +290,7 @@ tap.test(
           .set('Content-Type', 'application/json')
           .expect(200)
 
-        t.deepEqual(result.body.requestBody, requestData)
+        t.same(result.body.requestBody, requestData)
         t.ok(result.body.lookupRequests)
         t.end()
       }
@@ -391,7 +391,7 @@ tap.test(
         .set('Content-Type', 'application/json')
         .expect(500)
 
-      t.deepEqual(result.body, {
+      t.same(result.body, {
         error:
           'Input transform error: Object mapping schema invalid: No function exists for key: inValidFunction'
       })
@@ -490,8 +490,8 @@ tap.test(
         .set('Content-Type', 'application/json')
         .expect(200)
 
-      t.deepEqual(result.body.firstName, requestData.name)
-      t.deepEqual(result.body.lastName, requestData.surname)
+      t.same(result.body.firstName, requestData.name)
+      t.same(result.body.lastName, requestData.surname)
       t.ok(result.body.uptime)
       t.end()
     })
@@ -596,7 +596,7 @@ tap.test(
           .expect(200)
 
         t.ok(result.body['x-mediator-urn'])
-        t.equals(result.body.status, 'Successful')
+        t.equal(result.body.status, 'Successful')
         t.equal(result.body.orchestrations.length, 3)
         t.equal(
           result.body.orchestrations[1].name,

--- a/tests/integration/parser.js
+++ b/tests/integration/parser.js
@@ -119,8 +119,8 @@ tap.test(
           .set('Accept', 'application/json')
           .expect(200)
           .then(response => {
-            t.equals(response.body.test.name, 'Parser')
-            t.equals(typeof response.body.test.duration, 'number')
+            t.equal(response.body.test.name, 'Parser')
+            t.equal(typeof response.body.test.duration, 'number')
           })
 
         t.end()
@@ -160,8 +160,8 @@ tap.test(
           .set('Content-Type', 'application/xml')
           .set(OPENHIM_TRANSACTION_HEADER, 'requestUUID')
           .expect(response => {
-            t.equals(response.status, 400)
-            t.equals(
+            t.equal(response.status, 400)
+            t.equal(
               response.body.response.body,
               '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n<error>Parser Test Endpoint Bad XML output XML (requestUUID): Parsing incoming body failed: Bad Request</error>'
             )
@@ -204,8 +204,8 @@ tap.test(
           .set('Content-Type', 'application/xml')
           .set(OPENHIM_TRANSACTION_HEADER, 'requestUUID')
           .expect(response => {
-            t.equals(response.status, 400)
-            t.deepEqual(JSON.parse(response.body.response.body), {
+            t.equal(response.status, 400)
+            t.same(JSON.parse(response.body.response.body), {
               error:
                 'Parser Test Endpoint Bad XML output JSON (requestUUID): Parsing incoming body failed: Bad Request'
             })

--- a/tests/unit/cache.js
+++ b/tests/unit/cache.js
@@ -32,7 +32,7 @@ tap.test('Endpoint Cache', {autoend: true}, t => {
     cache.setupEventListeners()
 
     t.ok(modelWatchStub.calledOnce)
-    t.deepEquals(Object.keys(emitter._events), ['change', 'end', 'error'])
+    t.same(Object.keys(emitter._events), ['change', 'end', 'error'])
   })
 
   t.test('should listen for error events', t => {
@@ -71,7 +71,7 @@ tap.test('Endpoint Cache', {autoend: true}, t => {
 
   t.test('should listen for change event and update cache', async t => {
     t.plan(6)
-    t.equals(cache.endpointCache.length, 0)
+    t.equal(cache.endpointCache.length, 0)
 
     const emitter = new EventEmitter()
 
@@ -83,7 +83,7 @@ tap.test('Endpoint Cache', {autoend: true}, t => {
 
     cache.setupEventListeners()
 
-    t.deepEquals(Object.keys(emitter._events), ['change', 'end', 'error'])
+    t.same(Object.keys(emitter._events), ['change', 'end', 'error'])
 
     emitter.emit('change', {
       documentKey: {_id: '1234'},
@@ -108,7 +108,7 @@ tap.test('Endpoint Cache', {autoend: true}, t => {
     const modelWatchStub = sandbox.stub(EndpointModel, 'watch').returns(emitter)
 
     cache.setupEventListeners()
-    t.deepEquals(Object.keys(emitter._events), ['change', 'end', 'error'])
+    t.same(Object.keys(emitter._events), ['change', 'end', 'error'])
 
     cache.removeEventListeners()
     t.notOk(Object.keys(emitter._events).length)

--- a/tests/unit/dbService.js
+++ b/tests/unit/dbService.js
@@ -51,7 +51,7 @@ tap.test('Database interactions', {autoend: true}, t => {
             t.fail(`Should not reach here. ${data}`)
           })
           .catch(error => {
-            t.equals(
+            t.equal(
               error.message,
               'endpoint validation failed: transformation.output: Path `transformation.output` is required.'
             )
@@ -135,7 +135,7 @@ tap.test('Database interactions', {autoend: true}, t => {
         await createEndpoint(testEndpointConfig)
           .then(data => {
             t.ok(data.id)
-            t.equals(data.name, 'test')
+            t.equal(data.name, 'test')
           })
           .catch(error => {
             t.fail(`Should not reach here. ${error.message}`)
@@ -158,7 +158,7 @@ tap.test('Database interactions', {autoend: true}, t => {
             t.fail(`Should not reach here. ${data}`)
           })
           .catch(error => {
-            t.equals(
+            t.equal(
               error.message,
               'E11000 duplicate key error collection: unitTest.endpoints index: name_1 dup key: { name: "test" }'
             )
@@ -186,7 +186,7 @@ tap.test('Database interactions', {autoend: true}, t => {
         await createEndpoint(testEndpointConfig)
           .then(data => {
             t.ok(data.id)
-            t.equals(data.name, 'test 1')
+            t.equal(data.name, 'test 1')
           })
           .catch(error => {
             t.fail(`Should not reach here. ${error.message}`)
@@ -209,7 +209,7 @@ tap.test('Database interactions', {autoend: true}, t => {
             t.fail(`Should not reach here. ${data}`)
           })
           .catch(error => {
-            t.equals(
+            t.equal(
               error.message,
               'Duplicate error: regex created from endpoint pattern /test for matching requests already exists'
             )
@@ -222,7 +222,7 @@ tap.test('Database interactions', {autoend: true}, t => {
 
       await readEndpoints({})
         .then(data => {
-          t.equals(data.length, 0)
+          t.equal(data.length, 0)
         })
         .catch(error => {
           t.fail(`Should not reach here. ${error.message}`)
@@ -250,7 +250,7 @@ tap.test('Database interactions', {autoend: true}, t => {
 
       await readEndpoints({})
         .then(data => {
-          t.equals(data.length, 1)
+          t.equal(data.length, 1)
         })
         .catch(error => {
           t.fail(`Should not reach here. ${error.message}`)
@@ -262,7 +262,7 @@ tap.test('Database interactions', {autoend: true}, t => {
 
       await readEndpoints({})
         .then(data => {
-          t.equals(data.length, 0)
+          t.equal(data.length, 0)
         })
         .catch(error => {
           t.fail(`Should not reach here. ${error.message}`)
@@ -313,7 +313,7 @@ tap.test('Database interactions', {autoend: true}, t => {
             t.fail(`Should not reach here. ${data}`)
           })
           .catch(error => {
-            t.equals(
+            t.equal(
               error.message,
               'Parameter "filter" to find() must be an object, got Invalid'
             )
@@ -359,8 +359,8 @@ tap.test('Database interactions', {autoend: true}, t => {
       }
       await updateEndpoint(endpointId, updatedTestEndpointConfig)
         .then(data => {
-          t.equals(data.id, endpointId)
-          t.equals(data.name, 'updated test')
+          t.equal(data.id, endpointId)
+          t.equal(data.name, 'updated test')
         })
         .catch(error => {
           t.fail(`Should not reach here. ${error.message}`)
@@ -533,7 +533,7 @@ tap.test('Database interactions', {autoend: true}, t => {
             t.fail(`Should not reach here. ${data}`)
           })
           .catch(error => {
-            t.equals(
+            t.equal(
               error.message,
               'Validation failed: transformation.output: `Invalid` is not a valid enum value for path `transformation.output`.'
             )
@@ -568,8 +568,8 @@ tap.test('Database interactions', {autoend: true}, t => {
 
       await deleteEndpoint(endpointId)
         .then(data => {
-          t.equals(data.n, 1)
-          t.equals(data.deletedCount, 1)
+          t.equal(data.n, 1)
+          t.equal(data.deletedCount, 1)
         })
         .catch(error => {
           t.fail(`Should not reach here. ${error.message}`)
@@ -633,8 +633,8 @@ tap.test('Database interactions', {autoend: true}, t => {
         await deleteEndpoint('5e8d99cdbd40b81685123231')
           .then(data => {
             // The numbers here should be zero as the document did not exist
-            t.equals(data.n, 0)
-            t.equals(data.deletedCount, 0)
+            t.equal(data.n, 0)
+            t.equal(data.deletedCount, 0)
           })
           .catch(error => {
             t.fail(`Should not reach here. ${error.message}`)
@@ -651,7 +651,7 @@ tap.test('Database interactions', {autoend: true}, t => {
         try {
           await deleteEndpoint('Not Valid')
         } catch (error) {
-          t.equals(
+          t.equal(
             error.message,
             'Argument passed in must be a single String of 12 bytes or a string of 24 hex characters'
           )
@@ -703,8 +703,8 @@ tap.test('Database interactions', {autoend: true}, t => {
 
       await deleteEndpoints({})
         .then(data => {
-          t.equals(data.n, 2)
-          t.equals(data.deletedCount, 2)
+          t.equal(data.n, 2)
+          t.equal(data.deletedCount, 2)
         })
         .catch(error => {
           t.fail(`Should not reach here. ${error.message}`)

--- a/tests/unit/endpointRoutes.js
+++ b/tests/unit/endpointRoutes.js
@@ -46,8 +46,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
       }
     }
     const next = () => {
-      t.equals(ctx.status, 201)
-      t.deepEquals(ctx.body, result)
+      t.equal(ctx.status, 201)
+      t.same(ctx.body, result)
     }
     const router = {
       post: (_pattern, _parser, callback) => {
@@ -73,8 +73,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
         }
       }
       const next = () => {
-        t.equals(ctx.status, 400)
-        t.deepEquals(ctx.body, {error: 'Create endpoint failed:Boom!'})
+        t.equal(ctx.status, 400)
+        t.same(ctx.body, {error: 'Create endpoint failed:Boom!'})
       }
       const router = {
         post: (_pattern, _parser, callback) => {
@@ -99,8 +99,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
         }
       }
       const next = () => {
-        t.equals(ctx.status, 500)
-        t.deepEquals(ctx.body, {error: 'Create endpoint failed:Boom!'})
+        t.equal(ctx.status, 500)
+        t.same(ctx.body, {error: 'Create endpoint failed:Boom!'})
       }
       const router = {
         post: (_pattern, _parser, callback) => {
@@ -132,8 +132,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
       }
     }
     const next = () => {
-      t.equals(ctx.status, 200)
-      t.deepEquals(ctx.body, result)
+      t.equal(ctx.status, 200)
+      t.same(ctx.body, result)
     }
     const router = {
       get: (_pattern, callback) => {
@@ -158,8 +158,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
       }
     }
     const next = () => {
-      t.equals(ctx.status, 404)
-      t.deepEquals(ctx.body, {
+      t.equal(ctx.status, 404)
+      t.same(ctx.body, {
         error: 'Endpoint with ID 5e99568a50902917f2bc352b does not exist'
       })
     }
@@ -190,8 +190,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
         }
       }
       const next = () => {
-        t.equals(ctx.status, 500)
-        t.deepEquals(ctx.body, {
+        t.equal(ctx.status, 500)
+        t.same(ctx.body, {
           error: 'Retrieving of endpoint failed: MongoDB Error detected'
         })
       }
@@ -219,8 +219,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
         }
       }
       const next = () => {
-        t.equals(ctx.status, 400)
-        t.deepEquals(ctx.body, {
+        t.equal(ctx.status, 400)
+        t.same(ctx.body, {
           error:
             'Retrieving of endpoint failed: Endpoint ID supplied in url is invalid'
         })
@@ -261,8 +261,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
       }
     }
     const next = () => {
-      t.equals(ctx.status, 200)
-      t.deepEquals(ctx.body, result)
+      t.equal(ctx.status, 200)
+      t.same(ctx.body, result)
     }
     const router = {
       get: (_pattern, callback) => {
@@ -284,8 +284,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
       }
     }
     const next = () => {
-      t.equals(ctx.status, 500)
-      t.deepEquals(ctx.body, {error: 'Retrieving of endpoints failed: Boom!'})
+      t.equal(ctx.status, 500)
+      t.same(ctx.body, {error: 'Retrieving of endpoints failed: Boom!'})
     }
     const router = {
       get: (_pattern, callback) => {
@@ -307,8 +307,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
       }
     }
     const next = () => {
-      t.equals(ctx.status, 500)
-      t.deepEquals(ctx.body, {error: 'Retrieving of endpoints failed: Boom!'})
+      t.equal(ctx.status, 500)
+      t.same(ctx.body, {error: 'Retrieving of endpoints failed: Boom!'})
     }
     const router = {
       get: (_pattern, callback) => {
@@ -345,8 +345,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
       }
     }
     const next = () => {
-      t.equals(ctx.status, 200)
-      t.deepEquals(ctx.body, result)
+      t.equal(ctx.status, 200)
+      t.same(ctx.body, result)
       t.ok(stub.called)
     }
     const router = {
@@ -371,8 +371,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
       }
     }
     const next = () => {
-      t.equals(ctx.status, 400)
-      t.deepEquals(ctx.body, {
+      t.equal(ctx.status, 400)
+      t.same(ctx.body, {
         error:
           'Updating of endpoint failed: Endpoint ID supplied in url is invalid'
       })
@@ -400,8 +400,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
         }
       }
       const next = () => {
-        t.equals(ctx.status, 400)
-        t.deepEquals(ctx.body, {
+        t.equal(ctx.status, 400)
+        t.same(ctx.body, {
           error: 'Updating of endpoint failed: Invalid endpoint object'
         })
       }
@@ -436,8 +436,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
         }
       }
       const next = () => {
-        t.equals(ctx.status, 404)
-        t.deepEquals(ctx.body, {
+        t.equal(ctx.status, 404)
+        t.same(ctx.body, {
           error: 'Endpoint with ID 5e99568a50902917f2bc352b does not exist'
         })
         t.ok(stub.called)
@@ -471,8 +471,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
       }
     }
     const next = () => {
-      t.equals(ctx.status, 400)
-      t.deepEquals(ctx.body, {
+      t.equal(ctx.status, 400)
+      t.same(ctx.body, {
         error: 'Updating of endpoint failed: MongoDB Error Detected'
       })
       t.ok(stub.called)
@@ -500,8 +500,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
       }
     }
     const next = () => {
-      t.equals(ctx.status, 200)
-      t.deepEquals(ctx.body, {
+      t.equal(ctx.status, 200)
+      t.same(ctx.body, {
         message: "Endpoint with ID '5e99568a50902917f2bc352b' deleted"
       })
     }
@@ -522,8 +522,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
       }
     }
     const next = () => {
-      t.equals(ctx.status, 400)
-      t.deepEquals(ctx.body, {
+      t.equal(ctx.status, 400)
+      t.same(ctx.body, {
         error:
           'Endpoint deletion failed: Endpoint ID supplied in url is invalid'
       })
@@ -548,8 +548,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
       }
     }
     const next = () => {
-      t.equals(ctx.status, 404)
-      t.deepEquals(ctx.body, {
+      t.equal(ctx.status, 404)
+      t.same(ctx.body, {
         error: "Endpoint with ID '5e99568a50902917f2bc352b' does not exist"
       })
     }
@@ -575,8 +575,8 @@ tap.test('Endpoint Routes', {autoend: true}, async t => {
       }
     }
     const next = () => {
-      t.equals(ctx.status, 500)
-      t.deepEquals(ctx.body, {
+      t.equal(ctx.status, 500)
+      t.same(ctx.body, {
         error: 'Endpoint deletion failed: Mongo Error Detected!'
       })
     }

--- a/tests/unit/externalRequests.js
+++ b/tests/unit/externalRequests.js
@@ -36,7 +36,7 @@ tap.test('External Requests', {autoend: true}, t => {
       const status = 500
 
       const valid = validateRequestStatusCode(allowedStatuses)(status)
-      t.equals(valid, false)
+      t.equal(valid, false)
       t.end()
     })
 
@@ -45,7 +45,7 @@ tap.test('External Requests', {autoend: true}, t => {
       const status = 200
 
       const valid = validateRequestStatusCode(allowedStatuses)(status)
-      t.equals(valid, true)
+      t.equal(valid, true)
       t.end()
     })
 
@@ -54,7 +54,7 @@ tap.test('External Requests', {autoend: true}, t => {
       const status = 202
 
       const valid = validateRequestStatusCode(allowedStatuses)(status)
-      t.equals(valid, true)
+      t.equal(valid, true)
       t.end()
     })
   })
@@ -122,8 +122,8 @@ tap.test('External Requests', {autoend: true}, t => {
         try {
           await Promise.all(performLookupRequests(ctx, requests))
         } catch (error) {
-          t.equals(ctx.orchestrations.length, 1)
-          t.equals(ctx.state.allData.state.currentLookupNetworkError, true)
+          t.equal(ctx.orchestrations.length, 1)
+          t.equal(ctx.state.allData.state.currentLookupNetworkError, true)
           t.match(
             error.message,
             /No response from lookup '1233243'. connect ECONNREFUSED/
@@ -174,9 +174,12 @@ tap.test('External Requests', {autoend: true}, t => {
         try {
           await Promise.all(performLookupRequests(ctx, requests))
         } catch (error) {
-          t.equals(ctx.orchestrations.length, 1)
-          t.equals(ctx.state.allData.state.currentLookupHttpStatus, 400)
-          t.match(error.message, /Incorrect status code 400. Bad request/)
+          t.equal(ctx.orchestrations.length, 1)
+          t.equal(ctx.state.allData.state.currentLookupHttpStatus, 400)
+          t.same(
+            error.message,
+            `Incorrect status code 400. {"message":"Bad request"}`
+          )
           t.end()
         }
       }
@@ -220,9 +223,9 @@ tap.test('External Requests', {autoend: true}, t => {
       }
 
       await Promise.all(performLookupRequests(ctx, requests)).then(res => {
-        t.deepEqual(res[0]['123'].data, 'Body')
-        t.equals(ctx.state.allData.state.currentLookupHttpStatus, 200)
-        t.equals(ctx.orchestrations.length, 1)
+        t.same(res[0]['123'].data, 'Body')
+        t.equal(ctx.state.allData.state.currentLookupHttpStatus, 200)
+        t.equal(ctx.orchestrations.length, 1)
         t.end()
       })
     })
@@ -328,9 +331,9 @@ tap.test('External Requests', {autoend: true}, t => {
       }
       await prepareLookupRequests(ctx)
 
-      t.equals(ctx.orchestrations.length, 2)
+      t.equal(ctx.orchestrations.length, 2)
       t.ok(ctx.state.allData.lookupRequests)
-      t.deepEqual(ctx.state.allData.lookupRequests, {
+      t.same(ctx.state.allData.lookupRequests, {
         chrome: {
           data: 'Body',
           headers: {}
@@ -363,7 +366,7 @@ tap.test('External Requests', {autoend: true}, t => {
 
       await prepareResponseRequests(ctx)
 
-      t.equals(ctx.orchestrations, undefined)
+      t.equal(ctx.orchestrations, undefined)
       t.end()
     })
 
@@ -387,7 +390,7 @@ tap.test('External Requests', {autoend: true}, t => {
         }
         await prepareResponseRequests(ctx)
 
-        t.equals(ctx.orchestrations)
+        t.equal(ctx.orchestrations)
         t.end()
       }
     )
@@ -416,7 +419,7 @@ tap.test('External Requests', {autoend: true}, t => {
 
         await prepareResponseRequests(ctx)
 
-        t.equals(ctx.orchestrations, undefined)
+        t.equal(ctx.orchestrations, undefined)
         t.end()
       }
     )
@@ -445,7 +448,7 @@ tap.test('External Requests', {autoend: true}, t => {
         }
         await prepareResponseRequests(ctx)
 
-        t.equals(ctx.orchestrations.length, 0)
+        t.equal(ctx.orchestrations.length, 0)
         t.end()
       }
     )
@@ -504,7 +507,7 @@ tap.test('External Requests', {autoend: true}, t => {
 
         await prepareResponseRequests(ctx)
 
-        t.equals(ctx.orchestrations.length, 2)
+        t.equal(ctx.orchestrations.length, 2)
         t.match(ctx.orchestrations[0].error.message, /ECONNREFUSED/)
         t.end()
       }
@@ -660,8 +663,8 @@ tap.test('External Requests', {autoend: true}, t => {
 
       await prepareResponseRequests(ctx)
 
-      t.equals(ctx.orchestrations.length, 2)
-      t.deepEqual(ctx.orchestrations[1].response.body, JSON.stringify(response))
+      t.equal(ctx.orchestrations.length, 2)
+      t.same(ctx.orchestrations[1].response.body, JSON.stringify(response))
 
       t.end()
     })
@@ -718,9 +721,9 @@ tap.test('External Requests', {autoend: true}, t => {
 
         await prepareResponseRequests(ctx)
 
-        t.equals(ctx.orchestrations.length, 0)
+        t.equal(ctx.orchestrations.length, 0)
 
-        t.deepEqual(ctx.body, response)
+        t.same(ctx.body, response)
         t.end()
       }
     )
@@ -766,8 +769,8 @@ tap.test('External Requests', {autoend: true}, t => {
 
         prepareLookupRequests(ctx).catch(err => {
           performLookupRequestsStub()
-          t.type(err, Error)
-          t.equal(err.message, 'Rejected Promise: Fail')
+          t.type(err, 'string')
+          t.equal(err, 'Fail')
         })
       })
 
@@ -1076,11 +1079,7 @@ tap.test('External Requests', {autoend: true}, t => {
         prepareLookupRequests(ctx)
 
         performLookupRequestsStub()
-        t.equals(
-          called,
-          false,
-          'performLookupRequestsStub should not be called'
-        )
+        t.equal(called, false, 'performLookupRequestsStub should not be called')
         t.end()
       }
     )
@@ -1124,7 +1123,7 @@ tap.test('External Requests', {autoend: true}, t => {
         requestBody,
         queryParams
       )
-      t.equals(requestConfig.data, requestBody)
+      t.equal(requestConfig.data, requestBody)
       t.end()
     })
 
@@ -1169,7 +1168,7 @@ tap.test('External Requests', {autoend: true}, t => {
         queryParams,
         requestUrl
       )
-      t.equals(requestConfig.url, requestUrl)
+      t.equal(requestConfig.url, requestUrl)
       t.end()
     })
   })
@@ -1185,7 +1184,7 @@ tap.test('External Requests', {autoend: true}, t => {
       }
 
       setKoaResponseBody(ctx, request, body)
-      t.deepEqual(ctx.body[request.id], body)
+      t.same(ctx.body[request.id], body)
       t.end()
     })
 
@@ -1200,7 +1199,7 @@ tap.test('External Requests', {autoend: true}, t => {
       }
 
       setKoaResponseBody(ctx, request, null)
-      t.equals(ctx.body[request.id], undefined)
+      t.equal(ctx.body[request.id], undefined)
       t.end()
     })
   })
@@ -1219,10 +1218,10 @@ tap.test('External Requests', {autoend: true}, t => {
       const body = {message: 'success'}
 
       setKoaResponseBodyAndHeadersFromPrimary(ctx, status, headers, body)
-      t.deepEqual(ctx.status, status)
-      t.deepEqual(ctx.headers, headers)
-      t.deepEqual(ctx.body, body)
-      t.equals(ctx.hasPrimaryRequest, true)
+      t.same(ctx.status, status)
+      t.same(ctx.headers, headers)
+      t.same(ctx.body, body)
+      t.equal(ctx.hasPrimaryRequest, true)
       t.end()
     })
   })
@@ -1239,7 +1238,7 @@ tap.test('External Requests', {autoend: true}, t => {
 
       const result = handleRequestError(ctx, request, err)
 
-      t.deepEqual(result.error, err)
+      t.same(result.error, err)
       t.end()
     })
 
@@ -1261,8 +1260,8 @@ tap.test('External Requests', {autoend: true}, t => {
 
         const result = handleRequestError(ctx, request, err)
 
-        t.deepEqual(result.response.body, err.response.data)
-        t.equals(
+        t.same(result.response.body, err.response.data)
+        t.equal(
           ctx.routerResponseStatuses.includes('primaryReqFailError'),
           true
         )
@@ -1287,10 +1286,7 @@ tap.test('External Requests', {autoend: true}, t => {
         }
 
         handleRequestError(ctx, request, err)
-        t.equals(
-          ctx.routerResponseStatuses.includes('secondaryFailError'),
-          true
-        )
+        t.equal(ctx.routerResponseStatuses.includes('secondaryFailError'), true)
         t.end()
       }
     )
@@ -1313,8 +1309,8 @@ tap.test('External Requests', {autoend: true}, t => {
 
         const result = handleRequestError(ctx, request, err)
 
-        t.deepEqual(result.response.body, err.response.data)
-        t.equals(ctx.routerResponseStatuses.includes('primaryCompleted'), true)
+        t.same(result.response.body, err.response.data)
+        t.equal(ctx.routerResponseStatuses.includes('primaryCompleted'), true)
         t.end()
       }
     )
@@ -1337,11 +1333,8 @@ tap.test('External Requests', {autoend: true}, t => {
 
         const result = handleRequestError(ctx, request, err)
 
-        t.deepEqual(result.response.body, err.response.data)
-        t.equals(
-          ctx.routerResponseStatuses.includes('secondaryCompleted'),
-          true
-        )
+        t.same(result.response.body, err.response.data)
+        t.equal(ctx.routerResponseStatuses.includes('secondaryCompleted'), true)
         t.end()
       }
     )
@@ -1466,24 +1459,24 @@ tap.test('External Requests', {autoend: true}, t => {
 
       const params = addRequestQueryParameters(ctx, request)
 
-      t.equals(params.id, ctx.request.body.id)
-      t.equals(params.place, ctx.request.body.place.address)
-      t.equals(params.code, ctx.request.query.code)
-      t.equals(params.status, ctx.request.body.status[1].rich.status[0].sp)
-      t.equals(params.name, `${prefix + ctx.request.query.name + postfix}`)
+      t.equal(params.id, ctx.request.body.id)
+      t.equal(params.place, ctx.request.body.place.address)
+      t.equal(params.code, ctx.request.query.code)
+      t.equal(params.status, ctx.request.body.status[1].rich.status[0].sp)
+      t.equal(params.name, `${prefix + ctx.request.query.name + postfix}`)
       // Query params are strings therefore the digit will be converted
-      t.equals(params.floor, ctx.state.allData.transforms.floor.toString())
-      t.equals(
+      t.equal(params.floor, ctx.state.allData.transforms.floor.toString())
+      t.equal(
         params.children,
         ctx.state.allData.lookupRequests.children.toString()
       )
-      t.equals(params.brother, ctx.state.allData.responseBody.brother)
-      t.equals(params.lastAddress, ctx.state.allData.state.lastAddress)
-      t.equals(params.location, ctx.state.allData.urlParams.location)
-      t.equals(params.building, ctx.state.allData.transforms.building)
-      t.equals(params.extension, ctx.state.allData.transforms.extension)
-      t.equals(params.multiplier, ctx.state.allData.constants.multiplier)
-      t.equals(params.time, ctx.state.allData.timestamps.endpointStart)
+      t.equal(params.brother, ctx.state.allData.responseBody.brother)
+      t.equal(params.lastAddress, ctx.state.allData.state.lastAddress)
+      t.equal(params.location, ctx.state.allData.urlParams.location)
+      t.equal(params.building, ctx.state.allData.transforms.building)
+      t.equal(params.extension, ctx.state.allData.transforms.extension)
+      t.equal(params.multiplier, ctx.state.allData.constants.multiplier)
+      t.equal(params.time, ctx.state.allData.timestamps.endpointStart)
       t.notOk(params.moreInfo)
       t.end()
     })
@@ -1502,7 +1495,7 @@ tap.test('External Requests', {autoend: true}, t => {
       try {
         addRequestQueryParameters(ctx, request)
       } catch (error) {
-        t.equals(
+        t.equal(
           error.message,
           'Unsupported Query Parameter Extract Type: invalidPath'
         )
@@ -1514,7 +1507,7 @@ tap.test('External Requests', {autoend: true}, t => {
 
   t.test('resolveRequestUrl', {autoend: true}, t => {
     t.test('should return the request url if there are no url params', t => {
-      t.equals(
+      t.equal(
         resolveRequestUrl({}, {url: 'http://test.org'}),
         'http://test.org'
       )
@@ -1547,7 +1540,7 @@ tap.test('External Requests', {autoend: true}, t => {
           }
         }
       )
-      t.equals(
+      t.equal(
         url,
         'http://test.org/url/params/are/fun/params/to-test-thoroughly/'
       )
@@ -1582,7 +1575,7 @@ tap.test('External Requests', {autoend: true}, t => {
             }
           }
         )
-        t.equals(url, 'http://test.org/url/:test1/are/fun/:test1/:test2/')
+        t.equal(url, 'http://test.org/url/:test1/are/fun/:test1/:test2/')
         t.end()
       }
     )
@@ -1613,7 +1606,7 @@ tap.test('External Requests', {autoend: true}, t => {
           }
         }
       )
-      t.equals(url, 'http://test.org/url//are/fun//to-0-thoroughly/')
+      t.equal(url, 'http://test.org/url//are/fun//to-0-thoroughly/')
       t.end()
     })
   })

--- a/tests/unit/initiateMiddleware.js
+++ b/tests/unit/initiateMiddleware.js
@@ -112,7 +112,7 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
 
       const extractedObject = extractByType(type, extract, allData)
 
-      t.deepEqual(extractedObject, {})
+      t.same(extractedObject, {})
     })
 
     t.test('should return an empty object when "extract" not supplied', t => {
@@ -128,7 +128,7 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
 
       const extractedObject = extractByType(type, extract, allData)
 
-      t.deepEqual(extractedObject, {})
+      t.same(extractedObject, {})
     })
 
     t.test('should return an empty object when "allData" not supplied', t => {
@@ -144,7 +144,7 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
 
       const extractedObject = extractByType(type, extract, allData)
 
-      t.deepEqual(extractedObject, {})
+      t.same(extractedObject, {})
     })
 
     t.test(
@@ -166,7 +166,7 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
 
         const extractedObject = extractByType(type, extract, allData)
 
-        t.deepEqual(extractedObject, {
+        t.same(extractedObject, {
           stateQueryParam: 'queryParamValue'
         })
       }
@@ -340,19 +340,19 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
         endpointStart
       )
 
-      t.deepEqual(extractedStateValues.requestBody, {
+      t.same(extractedStateValues.requestBody, {
         statePropertyText: 'a property on a nested object',
         statePropertyArray0: 'one',
         statePropertyArray2: 'three'
       })
-      t.deepEqual(extractedStateValues.responseBody, {
+      t.same(extractedStateValues.responseBody, {
         statePropertyValueOne: 'two',
         statePropertyValueTwo: 'three'
       })
-      t.deepEqual(extractedStateValues.query, {
+      t.same(extractedStateValues.query, {
         statePropertyFromKey: 'queryParamValue'
       })
-      t.deepEqual(extractedStateValues.lookupRequests, {
+      t.same(extractedStateValues.lookupRequests, {
         firstRequest: {
           lookup1value: 'a response value from the first request'
         },
@@ -630,7 +630,7 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
         t.equal(endpoint._id, 'endpoint1')
         t.equal(endpoint.name, 'Endpoint 1')
         t.equal(endpoint.endpoint.pattern, '/path/:id')
-        t.deepEqual(urlParams, {id: id})
+        t.same(urlParams, {id: id})
         t.end()
       }
     )

--- a/tests/unit/mapper.js
+++ b/tests/unit/mapper.js
@@ -35,7 +35,7 @@ tap.test('Mapper', {autoend: true}, t => {
 
         createMappedObject(ctx)
 
-        t.deepEqual(ctx.body, {
+        t.same(ctx.body, {
           requestBody: ctx.state.allData.requestBody,
           lookupRequests: ctx.state.allData.lookupRequests
         })
@@ -65,7 +65,7 @@ tap.test('Mapper', {autoend: true}, t => {
 
         createMappedObject(ctx)
 
-        t.deepEqual(ctx.body, ctx.state.allData.requestBody)
+        t.same(ctx.body, ctx.state.allData.requestBody)
         t.end()
       }
     )
@@ -106,7 +106,7 @@ tap.test('Mapper', {autoend: true}, t => {
 
         createMappedObject(ctx)
 
-        t.deepEqual(ctx.body, expected)
+        t.same(ctx.body, expected)
         t.end()
       }
     )
@@ -158,8 +158,8 @@ tap.test('Mapper', {autoend: true}, t => {
 
         createMappedObject(ctx)
 
-        t.deepEqual(ctx.body, expected)
-        t.equals(ctx.status, 200)
+        t.same(ctx.body, expected)
+        t.equal(ctx.status, 200)
         t.end()
       }
     )
@@ -196,7 +196,7 @@ tap.test('Mapper', {autoend: true}, t => {
         try {
           createMappedObject(ctx)
         } catch (error) {
-          t.equals(
+          t.equal(
             error.message,
             'Object mapping schema invalid: No function exists for key: inValidFunction'
           )
@@ -245,9 +245,9 @@ tap.test('Mapper', {autoend: true}, t => {
 
       createMappedObject(ctx)
 
-      t.equals(ctx.orchestrations.length, 1)
-      t.equals(ctx.orchestrations[0].name, 'Endpoint Mapping: Testing endpoint')
-      t.deepEqual(ctx.orchestrations[0].response.body, JSON.stringify(expected))
+      t.equal(ctx.orchestrations.length, 1)
+      t.equal(ctx.orchestrations[0].name, 'Endpoint Mapping: Testing endpoint')
+      t.same(ctx.orchestrations[0].response.body, JSON.stringify(expected))
       t.end()
     })
 
@@ -294,15 +294,12 @@ tap.test('Mapper', {autoend: true}, t => {
 
         createMappedObject(ctx)
 
-        t.equals(ctx.orchestrations.length, 1)
-        t.equals(
+        t.equal(ctx.orchestrations.length, 1)
+        t.equal(
           ctx.orchestrations[0].name,
           'Endpoint Mapping: Testing endpoint'
         )
-        t.deepEqual(
-          ctx.orchestrations[0].response.body,
-          JSON.stringify(expected)
-        )
+        t.same(ctx.orchestrations[0].response.body, JSON.stringify(expected))
         t.end()
       }
     )

--- a/tests/unit/openhim.js
+++ b/tests/unit/openhim.js
@@ -26,7 +26,7 @@ tap.test('constructOpenhimResponse()', {autoend: true}, t => {
     try {
       mediatorSetup()
     } catch (error) {
-      t.equals(error.message, 'Boom')
+      t.equal(error.message, 'Boom')
     }
   })
 
@@ -102,7 +102,7 @@ tap.test('constructOpenhimResponse()', {autoend: true}, t => {
 
     constructOpenhimResponse(ctx, timestamp)
 
-    t.deepEqual(JSON.parse(ctx.body), expectedResponse)
+    t.same(JSON.parse(ctx.body), expectedResponse)
     t.end()
   })
 })

--- a/tests/unit/orchestrations.js
+++ b/tests/unit/orchestrations.js
@@ -18,7 +18,7 @@ tap.test('createOrchestrations()', {autoend: true}, t => {
     try {
       createOrchestration(request, null, reqTimestamp, null, name)
     } catch (error) {
-      t.equals(
+      t.equal(
         error.message,
         'Orchestration creation failed: required parameter not supplied - reqTimestamp | orchestrationName'
       )
@@ -38,7 +38,7 @@ tap.test('createOrchestrations()', {autoend: true}, t => {
     try {
       createOrchestration(request, null, reqTimestamp, null, null, name)
     } catch (error) {
-      t.equals(
+      t.equal(
         error.message,
         'Orchestration creation failed: required parameter not supplied - reqTimestamp | orchestrationName'
       )
@@ -102,7 +102,7 @@ tap.test('createOrchestrations()', {autoend: true}, t => {
       null
     )
 
-    t.deepEqual(expectedOrch, orchestration)
+    t.same(expectedOrch, orchestration)
     t.end()
   })
 
@@ -114,7 +114,7 @@ tap.test('createOrchestrations()', {autoend: true}, t => {
 
       setStatusText(ctx)
 
-      t.equals(ctx.statusText, 'Failed')
+      t.equal(ctx.statusText, 'Failed')
       t.end()
     })
 
@@ -125,7 +125,7 @@ tap.test('createOrchestrations()', {autoend: true}, t => {
 
       setStatusText(ctx)
 
-      t.equals(ctx.statusText, 'Completed with error(s)')
+      t.equal(ctx.statusText, 'Completed with error(s)')
       t.end()
     })
 
@@ -136,7 +136,7 @@ tap.test('createOrchestrations()', {autoend: true}, t => {
 
       setStatusText(ctx)
 
-      t.equals(ctx.statusText, 'Completed')
+      t.equal(ctx.statusText, 'Completed')
       t.end()
     })
 
@@ -149,7 +149,7 @@ tap.test('createOrchestrations()', {autoend: true}, t => {
 
         setStatusText(ctx)
 
-        t.equals(ctx.statusText, 'Completed')
+        t.equal(ctx.statusText, 'Completed')
         t.end()
       }
     )
@@ -159,7 +159,7 @@ tap.test('createOrchestrations()', {autoend: true}, t => {
 
       setStatusText(ctx)
 
-      t.equals(ctx.statusText, 'Successful')
+      t.equal(ctx.statusText, 'Successful')
       t.end()
     })
   })

--- a/tests/unit/parser.js
+++ b/tests/unit/parser.js
@@ -70,7 +70,7 @@ tap.test('Parser', {autoend: true}, t => {
         try {
           await parseIncomingBody(ctx, inputFormat)
         } catch (error) {
-          t.equals(
+          t.equal(
             error.message,
             `Supplied input format does not match incoming content-type: Expected json format, but received unsupported`
           )
@@ -107,10 +107,10 @@ tap.test('Parser', {autoend: true}, t => {
 
       await parseIncomingBody(ctx, inputFormat)
 
-      t.equals(ctx.orchestrations.length, 1)
-      t.equals(ctx.orchestrations[0].name, 'Incoming Parser')
-      t.equals(ctx.orchestrations[0].request.body, ctx.request.raw_body)
-      t.equals(
+      t.equal(ctx.orchestrations.length, 1)
+      t.equal(ctx.orchestrations[0].name, 'Incoming Parser')
+      t.equal(ctx.orchestrations[0].request.body, ctx.request.raw_body)
+      t.equal(
         ctx.orchestrations[0].response.body,
         JSON.stringify(ctx.request.body)
       )
@@ -149,10 +149,10 @@ tap.test('Parser', {autoend: true}, t => {
 
         await parseIncomingBody(ctx, inputFormat)
 
-        t.equals(ctx.orchestrations.length, 1)
-        t.equals(ctx.orchestrations[0].name, 'Incoming Parser')
-        t.equals(ctx.orchestrations[0].request.body, ctx.request.raw_body)
-        t.equals(
+        t.equal(ctx.orchestrations.length, 1)
+        t.equal(ctx.orchestrations[0].name, 'Incoming Parser')
+        t.equal(ctx.orchestrations[0].request.body, ctx.request.raw_body)
+        t.equal(
           ctx.orchestrations[0].response.body,
           JSON.stringify(ctx.request.body)
         )
@@ -218,7 +218,7 @@ tap.test('Parser', {autoend: true}, t => {
     await parseIncomingBody(ctx, inputFormat)
       .then(() => t.fail('Should not reach here'))
       .catch(error => {
-        t.equals(error.message, `Cannot read property 'query' of null`)
+        t.equal(error.message, `Cannot read property 'query' of null`)
       })
     t.end()
   })
@@ -277,8 +277,8 @@ tap.test('Parser', {autoend: true}, t => {
 
       parseOutgoingBody(ctx, outputFormat)
 
-      t.deepEqual(ctx.body, expectedBody)
-      t.deepEqual(ctx.headers, expectedHeader)
+      t.same(ctx.body, expectedBody)
+      t.same(ctx.headers, expectedHeader)
       t.end()
     })
 
@@ -315,10 +315,10 @@ tap.test('Parser', {autoend: true}, t => {
 
         parseOutgoingBody(ctx, outputFormat)
 
-        t.equals(JSON.parse(ctx.body).status, 'Successful')
-        t.deepEqual(ctx.headers, expectedHeader)
-        t.equals(ctx.orchestrations.length, 1)
-        t.equals(ctx.orchestrations[0].name, 'Outgoing Parser')
+        t.equal(JSON.parse(ctx.body).status, 'Successful')
+        t.same(ctx.headers, expectedHeader)
+        t.equal(ctx.orchestrations.length, 1)
+        t.equal(ctx.orchestrations[0].name, 'Outgoing Parser')
         t.end()
       }
     )
@@ -364,10 +364,10 @@ tap.test('Parser', {autoend: true}, t => {
 
         parseOutgoingBody(ctx, outputFormat)
 
-        t.deepEqual(ctx.headers, expectedHeader)
-        t.equals(ctx.orchestrations.length, 1)
-        t.equals(ctx.orchestrations[0].name, 'Outgoing Parser')
-        t.equals(ctx.orchestrations[0].response.body, expectedBody)
+        t.same(ctx.headers, expectedHeader)
+        t.equal(ctx.orchestrations.length, 1)
+        t.equal(ctx.orchestrations[0].name, 'Outgoing Parser')
+        t.equal(ctx.orchestrations[0].response.body, expectedBody)
         t.end()
       }
     )
@@ -395,7 +395,7 @@ tap.test('Parser', {autoend: true}, t => {
         }
 
         const next = () => {
-          t.equals(ctx.status, 400)
+          t.equal(ctx.status, 400)
           t.same(ctx.body, {
             error:
               'Test endpoint (unique-id): transformation method "INVALID" not yet supported'
@@ -445,7 +445,7 @@ tap.test('Parser', {autoend: true}, t => {
       }
       await parseBodyMiddleware()(ctx, next)
 
-      t.equals(
+      t.equal(
         ctx.body,
         [
           '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',

--- a/tests/unit/stateService.js
+++ b/tests/unit/stateService.js
@@ -48,7 +48,7 @@ tap.test('States DB Services', {autoend: true}, t => {
             t.fail(`Should not reach here. ${data}`)
           })
           .catch(error => {
-            t.equals(
+            t.equal(
               error.message,
               'state validation failed: _endpointReference: Path `_endpointReference` is required.'
             )
@@ -78,7 +78,7 @@ tap.test('States DB Services', {autoend: true}, t => {
             t.fail(`Should not reach here. ${data}`)
           })
           .catch(error => {
-            t.equals(
+            t.equal(
               error.message,
               'state validation failed: system.timestamps.endpointStart: Path `system.timestamps.endpointStart` is invalid (Not a valid timestamp)., system.timestamps.endpointEnd: Path `system.timestamps.endpointEnd` is required.'
             )
@@ -105,13 +105,13 @@ tap.test('States DB Services', {autoend: true}, t => {
       }
       await createEndpointState(stateObject)
         .then(data => {
-          t.deepEquals(
+          t.same(
             data._endpointReference,
             new ObjectId('507f1f77bcf86cd799439011')
           )
-          t.equals(data.system.timestamps.endpointStart, endpointStart)
-          t.equals(data.system.timestamps.endpointEnd, endpointEnd)
-          t.equals(
+          t.equal(data.system.timestamps.endpointStart, endpointStart)
+          t.equal(data.system.timestamps.endpointEnd, endpointEnd)
+          t.equal(
             data.system.timestamps.endpointDuration.milliseconds,
             endpointDurationMs
           )
@@ -216,15 +216,15 @@ tap.test('States DB Services', {autoend: true}, t => {
         await readLatestEndpointStateById(endpointId, 'no-filter', [])
           .then(data => {
             t.ok(data._id)
-            t.deepEquals(data._endpointReference, endpointId)
-            t.equals(data.system.timestamps.endpointStart, endpointStart2)
-            t.equals(data.system.timestamps.endpointEnd, endpointEnd2)
-            t.equals(
+            t.same(data._endpointReference, endpointId)
+            t.equal(data.system.timestamps.endpointStart, endpointStart2)
+            t.equal(data.system.timestamps.endpointEnd, endpointEnd2)
+            t.equal(
               data.system.timestamps.endpointDuration.milliseconds,
               endpointDurationMs2
             )
-            t.equals(data.lookupNetworkError, false)
-            t.equals(data.lookupHttpStatus, 200)
+            t.equal(data.lookupNetworkError, false)
+            t.equal(data.lookupHttpStatus, 200)
           })
           .catch(error => {
             t.fail(`Should not reach here. ${error.message}`)
@@ -247,7 +247,7 @@ tap.test('States DB Services', {autoend: true}, t => {
             t.fail(`Should not reach here. ${JSON.stringify(data)}`)
           })
         } catch (error) {
-          t.equals(error.message, `Invalid HTTP Status filter`)
+          t.equal(error.message, `Invalid HTTP Status filter`)
         }
       }
     )
@@ -328,15 +328,15 @@ tap.test('States DB Services', {autoend: true}, t => {
         await readLatestEndpointStateById(endpointId, 'include', ['5xx'])
           .then(data => {
             t.ok(data._id)
-            t.deepEquals(data._endpointReference, endpointId)
-            t.equals(data.system.timestamps.endpointStart, endpointStart2)
-            t.equals(data.system.timestamps.endpointEnd, endpointEnd2)
-            t.equals(
+            t.same(data._endpointReference, endpointId)
+            t.equal(data.system.timestamps.endpointStart, endpointStart2)
+            t.equal(data.system.timestamps.endpointEnd, endpointEnd2)
+            t.equal(
               data.system.timestamps.endpointDuration.milliseconds,
               endpointDurationMs2
             )
-            t.equals(data.lookupNetworkError, true)
-            t.equals(data.lookupHttpStatus, 502)
+            t.equal(data.lookupNetworkError, true)
+            t.equal(data.lookupHttpStatus, 502)
           })
           .catch(error => {
             t.fail(`Should not reach here. ${error.message}`)
@@ -447,15 +447,15 @@ tap.test('States DB Services', {autoend: true}, t => {
         await readLatestEndpointStateById(endpointId, 'exclude', ['301'])
           .then(data => {
             t.ok(data._id)
-            t.deepEquals(data._endpointReference, endpointId)
-            t.equals(data.system.timestamps.endpointStart, endpointStart1)
-            t.equals(data.system.timestamps.endpointEnd, endpointEnd1)
-            t.equals(
+            t.same(data._endpointReference, endpointId)
+            t.equal(data.system.timestamps.endpointStart, endpointStart1)
+            t.equal(data.system.timestamps.endpointEnd, endpointEnd1)
+            t.equal(
               data.system.timestamps.endpointDuration.milliseconds,
               endpointDurationMs1
             )
-            t.equals(data.lookupNetworkError, false)
-            t.equals(data.lookupHttpStatus, 301)
+            t.equal(data.lookupNetworkError, false)
+            t.equal(data.lookupHttpStatus, 301)
           })
           .catch(error => {
             t.fail(`Should not reach here. ${error.message}`)

--- a/tests/unit/transformerMiddleware.js
+++ b/tests/unit/transformerMiddleware.js
@@ -92,7 +92,7 @@ tap.test('Transformer Middleware', {autoend: true}, t => {
 
         await jsonataTransformer(ctx)
 
-        t.deepEquals(ctx.state.allData.transforms, {
+        t.same(ctx.state.allData.transforms, {
           totalAmount: 1100,
           bmi: 25.54,
           patientReference: 'Patient/a-random-uuid'
@@ -197,7 +197,7 @@ tap.test('Transformer Middleware', {autoend: true}, t => {
       }
 
       const next = () => {
-        t.deepEquals(ctx.state.allData.transforms, {
+        t.same(ctx.state.allData.transforms, {
           totalAmount: 1100,
           bmi: 25.54,
           patientReference: 'Patient/a-random-uuid'


### PR DESCRIPTION
Make the error returned more descriptive and add ability to return a fhir response error from a lookup or response request (done by specifying the property `fhirResponse`  to true in the endpoint schema 