### PR TITLE
Tb 181 make endpoints unique by pattern and method

### DIFF
--- a/src/db/models/endpoints.js
+++ b/src/db/models/endpoints.js
@@ -35,10 +35,7 @@ const endpointSchema = new mongoose.Schema(
       pattern: {
         type: String,
         match: MIDDLEWARE_PATH_REGEX,
-        required: true,
-        index: {
-          unique: true
-        }
+        required: true
       },
       method: {
         type: String,
@@ -108,6 +105,11 @@ const endpointSchema = new mongoose.Schema(
     minimize: false,
     timestamps: true // set the created_at/updated_at timestamps on the record
   }
+)
+
+endpointSchema.index(
+  {'endpoint.pattern': 1, 'endpoint.method': 1},
+  {unique: true}
 )
 
 endpointSchema.pre('findOneAndUpdate', async function (next) {

--- a/src/middleware/initiate.js
+++ b/src/middleware/initiate.js
@@ -113,22 +113,24 @@ const updateEndpointState = async (ctx, endpoint) => {
     })
 }
 
-const getEndpointByPath = urlPath => {
+const getEndpointByPathAndMethod = (urlPath, method) => {
   let matchedEndpoint
   let urlParams = {}
 
   for (let endpoint of endpointCache) {
-    if (endpoint.endpoint.pattern === urlPath) {
-      return {endpoint: JSON.parse(JSON.stringify(endpoint)), urlParams}
-    }
+    if (endpoint.endpoint.method.toLowerCase() === method.toLowerCase()) {
+      if (endpoint.endpoint.pattern === urlPath) {
+        return {endpoint: JSON.parse(JSON.stringify(endpoint)), urlParams}
+      }
 
-    const match = urlPath.match(
-      extractRegexFromPattern(endpoint.endpoint.pattern)
-    )
+      const match = urlPath.match(
+        extractRegexFromPattern(endpoint.endpoint.pattern)
+      )
 
-    if (match) {
-      urlParams = match.groups ? match.groups : {}
-      matchedEndpoint = JSON.parse(JSON.stringify(endpoint))
+      if (match) {
+        urlParams = match.groups ? match.groups : {}
+        matchedEndpoint = JSON.parse(JSON.stringify(endpoint))
+      }
     }
   }
 
@@ -143,7 +145,10 @@ exports.initiateContextMiddleware = () => async (ctx, next) => {
     ? ctx.request.headers[OPENHIM_TRANSACTION_HEADER]
     : uuid.v4()
 
-  const {endpoint, urlParams} = getEndpointByPath(ctx.request.path)
+  const {endpoint, urlParams} = getEndpointByPathAndMethod(
+    ctx.request.path,
+    ctx.request.method
+  )
 
   if (!endpoint) {
     logger.error(`Unknown Endpoint: ${ctx.request.path}`)

--- a/tests/integration/externalRequests.js
+++ b/tests/integration/externalRequests.js
@@ -1558,7 +1558,8 @@ tap.test(
           const testEndpoint = {
             name: 'External Request Test Endpoint 18',
             endpoint: {
-              pattern: '/externalRequestTest18'
+              pattern: '/externalRequestTest18',
+              method: 'GET'
             },
             transformation: {
               input: 'JSON',

--- a/tests/integration/integration.js
+++ b/tests/integration/integration.js
@@ -247,7 +247,8 @@ tap.test(
           const testEndpoint = {
             name: 'Integration Test Endpoint 2',
             endpoint: {
-              pattern: '/integrationTest2'
+              pattern: '/integrationTest2',
+              method: 'GET'
             },
             transformation: {
               input: 'JSON',

--- a/tests/unit/initiateMiddleware.js
+++ b/tests/unit/initiateMiddleware.js
@@ -12,7 +12,7 @@ const {OPENHIM_TRANSACTION_HEADER} = require('../../src/constants')
 const extractByType = initiate.__get__('extractByType')
 const extractStateValues = initiate.__get__('extractStateValues')
 const updateEndpointState = initiate.__get__('updateEndpointState')
-const getEndpointByPath = initiate.__get__('getEndpointByPath')
+const getEndpointByPathAndMethod = initiate.__get__('getEndpointByPathAndMethod')
 
 const endpointStart = DateTime.utc().toISO()
 const defaultEndpoint = {
@@ -531,7 +531,7 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
     })
   })
 
-  t.test('getEndpointByPath', {autoend: true}, t => {
+  t.test('getEndpointByPathAndMethod', {autoend: true}, t => {
     t.test('should return the endpoint for the supplied path', async t => {
       t.plan(3)
       const endpointCache = [
@@ -539,14 +539,16 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
           _id: 'endpoint1',
           name: 'Endpoint 1',
           endpoint: {
-            pattern: '/path'
+            pattern: '/path',
+            method: 'post'
           }
         },
         {
           _id: 'endpoint2',
           name: 'Endpoint 2',
           endpoint: {
-            pattern: '/path-2'
+            pattern: '/path-2',
+            method: 'post'
           }
         }
       ]
@@ -556,7 +558,7 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
         endpointCache
       )
 
-      const {endpoint} = getEndpointByPath('/path')
+      const {endpoint} = getEndpointByPathAndMethod('/path', 'post')
 
       endpointCacheMockRevert()
 
@@ -573,14 +575,16 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
           _id: 'endpoint1',
           name: 'Endpoint 1',
           endpoint: {
-            pattern: '/path'
+            pattern: '/path',
+            method: 'post'
           }
         },
         {
           _id: 'endpoint2',
           name: 'Endpoint 2',
           endpoint: {
-            pattern: '/path-2'
+            pattern: '/path-2',
+            method: 'post'
           }
         }
       ]
@@ -590,7 +594,7 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
         endpointCache
       )
 
-      const {endpoint} = getEndpointByPath('/path-doesnt-exist')
+      const {endpoint} = getEndpointByPathAndMethod('/path-doesnt-exist', 'post')
 
       endpointCacheMockRevert()
 
@@ -605,14 +609,16 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
             _id: 'endpoint1',
             name: 'Endpoint 1',
             endpoint: {
-              pattern: '/path/:id'
+              pattern: '/path/:id',
+              method: 'post'
             }
           },
           {
             _id: 'endpoint2',
             name: 'Endpoint 2',
             endpoint: {
-              pattern: '/path2/:id'
+              pattern: '/path2/:id',
+              method: 'post'
             }
           }
         ]
@@ -623,7 +629,7 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
         )
 
         const id = '123334'
-        const {endpoint, urlParams} = getEndpointByPath(`/path/${id}`)
+        const {endpoint, urlParams} = getEndpointByPathAndMethod(`/path/${id}`, 'post')
 
         endpointCacheMockRevert()
 
@@ -693,8 +699,8 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
         response: {}
       }
 
-      const getEndpointByPathMockRevert = initiate.__set__(
-        'getEndpointByPath',
+      const getEndpointByPathAndMethodMockRevert = initiate.__set__(
+        'getEndpointByPathAndMethod',
         () => {
           return {
             endpoint: {
@@ -742,7 +748,7 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
       })
 
       // revert the mock function changes
-      getEndpointByPathMockRevert()
+      getEndpointByPathAndMethodMockRevert()
       updateEndpointStateMockRevert()
 
       t.equal(ctxMock.status, 500)
@@ -764,8 +770,8 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
         response: {}
       }
 
-      const getEndpointByPathMockRevert = initiate.__set__(
-        'getEndpointByPath',
+      const getEndpointByPathAndMethodMockRevert = initiate.__set__(
+        'getEndpointByPathAndMethod',
         () => {
           return {
             endpoint: {
@@ -808,7 +814,7 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
       })
 
       // revert the mock function changes
-      getEndpointByPathMockRevert()
+      getEndpointByPathAndMethodMockRevert()
     })
   })
 })

--- a/tests/unit/initiateMiddleware.js
+++ b/tests/unit/initiateMiddleware.js
@@ -12,7 +12,9 @@ const {OPENHIM_TRANSACTION_HEADER} = require('../../src/constants')
 const extractByType = initiate.__get__('extractByType')
 const extractStateValues = initiate.__get__('extractStateValues')
 const updateEndpointState = initiate.__get__('updateEndpointState')
-const getEndpointByPathAndMethod = initiate.__get__('getEndpointByPathAndMethod')
+const getEndpointByPathAndMethod = initiate.__get__(
+  'getEndpointByPathAndMethod'
+)
 
 const endpointStart = DateTime.utc().toISO()
 const defaultEndpoint = {
@@ -594,7 +596,10 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
         endpointCache
       )
 
-      const {endpoint} = getEndpointByPathAndMethod('/path-doesnt-exist', 'post')
+      const {endpoint} = getEndpointByPathAndMethod(
+        '/path-doesnt-exist',
+        'post'
+      )
 
       endpointCacheMockRevert()
 
@@ -629,7 +634,10 @@ tap.test('Initiate Middleware', {autoend: true}, t => {
         )
 
         const id = '123334'
-        const {endpoint, urlParams} = getEndpointByPathAndMethod(`/path/${id}`, 'post')
+        const {endpoint, urlParams} = getEndpointByPathAndMethod(
+          `/path/${id}`,
+          'post'
+        )
 
         endpointCacheMockRevert()
 


### PR DESCRIPTION
The endpoint is now unique by a combination of the endpoint's pattern and the http method. This allows us to have multiple endpoints with the same url but different http methods